### PR TITLE
Add upgrade test to the dags

### DIFF
--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -25,13 +25,13 @@ releases:
     tags: 
       - stable
   - version: 4.7
-    releaseStream: 4.7.0-0.nightly
+    releaseStream: 4-stable
     platform: aws
     profile: default
     tags:
       - next
   - version: 4.7
-    releaseStream: 4.7.0-0.nightly
+    releaseStream: 4-stable
     platform: aws
     profile: ovn
     tags:
@@ -58,7 +58,7 @@ releases:
       - next
       - xlarge
   - version: 4.7
-    releaseStream: 4.7.0-0.nightly
+    releaseStream: 4-stable
     platform: gcp
     profile: default
     tags: 

--- a/dags/openshift_nightlies/tasks/benchmarks/defaults.json
+++ b/dags/openshift_nightlies/tasks/benchmarks/defaults.json
@@ -52,6 +52,44 @@
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true"
             }
+        },
+	{
+            "name": "scale",
+            "workload": "scale-perf",
+            "command": "./run_scale_fromgit.sh",
+            "env": {
+                "SCALE": "50",
+                "METADATA_COLLECTION": "true",
+                "WORKLOAD_NODE_ROLE": "workload"
+            }
+        },
+        {
+            "name": "cluster_density",
+            "workload": "kube-burner",
+            "command": "./run_clusterdensity_test_fromgit.sh",
+            "env": {
+                "JOB_ITERATIONS":"1000",
+                "JOB_TIMEOUT":"18000",
+                "STEP_SIZE": "30s",
+                "QPS":"20",
+                "BURST":"20",
+                "METRICS_PROFILE":"metrics-aggregated.yaml",
+                "LOG_LEVEL":"info",
+                "LOG_STREAMING":"true",
+                "CLEANUP_WHEN_FINISH": "false",
+                "CLEANUP": "true"
+            }
+        },
+        {
+            "name": "upgrades",
+            "workload": "upgrade-perf",
+            "command": "./run_upgrade_fromgit.sh",
+            "env": {
+                "LATEST": "true",
+                "CHANNEL": "nightlies",
+                "TIMEOUT": "400",
+                "POLL_INTERVAL": "10"
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
This commit:
- Modifies the manifest for 4.7 dags to use stable releases vs nightlies.
  This is needed as the release nightlies do not have a supported upgrade
  path to release+1.
- Adds upgrade test which includes scaling up the cluster to 50 nodes,
  running cluster density with 1000 job-iterations and running the upgrade.
