### PR TITLE
Install Abstract Base Class and Developer playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ To install Airflow you simply need to fork the repo and run the following on a b
 ```bash
 # all commands are run at the root of your git repo
 # install the airflow stack and have it point to your fork of the dag code.
-./scripts/install.sh
+# $PASSWORD refers to the password you would like to secure your airflow instance behind.
+./scripts/install.sh -p $PASSWORD
 ```
 
 ### Getting Cluster Configuration
@@ -33,3 +34,20 @@ To get URLs and login info for the cluster, you can run `./scripts/get_cluster_i
 ### Uninstalling
 
 To uninstall the stack, you can run `./scripts/uninstall.sh`.
+
+
+
+
+## Installing Airflow (Developer Playground)
+
+To install Airflow in a developer playground setting (i.e. in our baremetal cluster)
+
+```bash
+# all commands are run at the root of your git repo
+# install the airflow stack and have it point to your fork of the dag code.
+# $PASSWORD refers to the password you would like to secure your airflow instance with.
+./scripts/playground/build.sh -p $PASSWORD
+```
+
+## Cleaning up the Playground
+To uninstall the stack, you can run `./scripts/playground/cleanup.sh`.

--- a/dags/openshift_nightlies/dag.py
+++ b/dags/openshift_nightlies/dag.py
@@ -86,7 +86,7 @@ class OpenshiftNightlyDAG():
         if self.platform == "baremetal":
             return jetski.BaremetalOpenshiftInstaller(self.dag, self.version, self.release_stream, self.platform, self.profile, self.version_alias)
         else:
-            return openshift.OpenshiftInstaller(self.dag, self.version, self.release_stream, self.latest_release, self.platform, self.profile)
+            return openshift.CloudOpenshiftInstaller(self.dag, self.version, self.release_stream, self.latest_release, self.platform, self.profile)
 
     def _get_e2e_benchmarks(self): 
         return e2e.E2EBenchmarks(self.dag, self.version, self.release_stream, self.latest_release, self.platform, self.profile, self.metadata_args)

--- a/dags/openshift_nightlies/tasks/install/cloud/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/cloud/openshift.py
@@ -5,6 +5,7 @@ from os import environ
 sys.path.insert(0, dirname(dirname(dirname(abspath(dirname(__file__))))))
 from util import var_loader, kubeconfig, constants
 from tasks.index.status import StatusIndexer
+from tasks.install.openshift import AbstractOpenshiftInstaller
 
 import json
 import requests
@@ -14,108 +15,9 @@ from airflow.models import Variable
 from kubernetes.client import models as k8s
 
 # Defines Tasks for installation of Openshift Clusters
-class OpenshiftInstaller():
-    def __init__(self, dag, version, release_stream, latest_release, platform, profile):
-
-        self.exec_config = {
-            "pod_override": k8s.V1Pod(
-                spec=k8s.V1PodSpec(
-                    containers=[
-                        k8s.V1Container(
-                            name="base",
-                            image="quay.io/keithwhitley4/airflow-ansible:2.0.0",
-                            image_pull_policy="Always",
-                            volume_mounts=[
-                                kubeconfig.get_empty_dir_volume_mount()]
-
-                        )
-                    ],
-                    volumes=[kubeconfig.get_empty_dir_volume_mount()]
-                )
-            )
-        }
-
-        # General DAG Configuration
-        self.dag = dag
-        self.platform = platform  # e.g. aws
-        self.version = version  # e.g. 4.6/4.7, major.minor only
-        self.release_stream = release_stream # true release stream to follow. Nightlies, CI, etc. 
-        self.latest_release = latest_release # latest relase from the release stream
-        self.profile = profile  # e.g. default/ovn
-
-        # Specific Task Configuration
-        self.vars = var_loader.build_task_vars(
-            task="install", version=version, platform=platform, profile=profile)
-
-        # Airflow Variables
-        self.ansible_orchestrator = Variable.get(
-            "ansible_orchestrator", deserialize_json=True)
-
-        
-        self.install_secrets = Variable.get(
-            f"openshift_install_config", deserialize_json=True)
-        self.aws_creds = Variable.get("aws_creds", deserialize_json=True)
-        self.gcp_creds = Variable.get("gcp_creds", deserialize_json=True)
-        self.azure_creds = Variable.get("azure_creds", deserialize_json=True)
-
-    def get_install_task(self):
-        indexer = StatusIndexer(self.dag, self.version, self.release_stream, self.latest_release, self.platform, self.profile, "install").get_index_task() 
-        install_task = self._get_task(operation="install")
-        install_task >> indexer 
-        return install_task
-
-    def get_cleanup_task(self):
-        # trigger_rule = "all_done" means this task will run when every other task has finished, whether it fails or succeededs
-        return self._get_task(operation="cleanup")
-
+class CloudOpenshiftInstaller(AbstractOpenshiftInstaller):
     # Create Airflow Task for Install/Cleanup steps
     def _get_task(self, operation="install", trigger_rule="all_success"):
-        playbook_operations = {}
-        if operation == "install":
-            playbook_operations = {"openshift_cleanup": True, "openshift_debug_config": False,
-                                   "openshift_install": True, "openshift_post_config": True, "openshift_post_install": True}
-        else:
-            playbook_operations = {"openshift_cleanup": True, "openshift_debug_config": False,
-                                   "openshift_install": False, "openshift_post_config": False, "openshift_post_install": False}
-
-        # Merge all variables, prioritizing Airflow Secrets over git based vars
-        config = {
-            **self.vars,
-            **self.ansible_orchestrator,
-            **self.install_secrets,
-            **self.aws_creds,
-            **self.gcp_creds,
-            **self.azure_creds,
-            **playbook_operations,
-            **self.latest_release,
-            **{ "es_server": var_loader.get_elastic_url() }
-        }
-
-        
-        git_user = var_loader.get_git_user()
-        if git_user == 'cloud-bulldozer':
-            config['openshift_cluster_name'] = f"ci-{self.version}-{self.platform}-{self.profile}"
-        else: 
-            config['openshift_cluster_name'] = f"{git_user}-{self.version}-{self.platform}-{self.profile}"
-
-        config['dynamic_deploy_path'] = f"{config['openshift_cluster_name']}"
-        config['kubeconfig_path'] = f"/root/{config['dynamic_deploy_path']}/auth/kubeconfig"
-        # Required Environment Variables for Install script
-        env = {
-            "SSHKEY_TOKEN": config['sshkey_token'],
-            "ORCHESTRATION_HOST": config['orchestration_host'],
-            "ORCHESTRATION_USER": config['orchestration_user'],
-            "OPENSHIFT_CLUSTER_NAME": config['openshift_cluster_name'],
-            "DEPLOY_PATH": config['dynamic_deploy_path'],
-            "KUBECONFIG_NAME": f"{self.version}-{self.platform}-{self.profile}-kubeconfig",
-            "KUBEADMIN_NAME": f"{self.version}-{self.platform}-{self.profile}-kubeadmin",
-            **self._insert_kube_env()
-        }
-
-        # Dump all vars to json file for Ansible to pick up
-        with open(f"/tmp/{self.version}-{self.platform}-{self.profile}-{operation}-task.json", 'w') as json_file:
-            json.dump(config, json_file, sort_keys=True, indent=4)
-
         return BashOperator(
             task_id=f"{operation}",
             depends_on_past=False,
@@ -124,11 +26,5 @@ class OpenshiftInstaller():
             dag=self.dag,
             trigger_rule=trigger_rule,
             executor_config=self.exec_config,
-            env=env
+            env=self.env
         )
-
-
-    # This Helper Injects Airflow environment variables into the task execution runtime
-    # This allows the task to interface with the Kubernetes cluster Airflow is hosted on.
-    def _insert_kube_env(self):
-        return {key: value for (key, value) in environ.items() if "KUBERNETES" in key}

--- a/dags/openshift_nightlies/tasks/install/cloud/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/cloud/openshift.py
@@ -18,6 +18,7 @@ from kubernetes.client import models as k8s
 class CloudOpenshiftInstaller(AbstractOpenshiftInstaller):
     # Create Airflow Task for Install/Cleanup steps
     def _get_task(self, operation="install", trigger_rule="all_success"):
+        self._setup_task(operation=operation)
         return BashOperator(
             task_id=f"{operation}",
             depends_on_past=False,

--- a/dags/openshift_nightlies/tasks/install/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/openshift.py
@@ -1,0 +1,129 @@
+import sys
+import abc
+from os.path import abspath, dirname
+from os import environ
+
+
+sys.path.insert(0, dirname(dirname(abspath(dirname(__file__)))))
+from util import var_loader, kubeconfig, constants
+from tasks.index.status import StatusIndexer
+
+import json
+import requests
+from abc import ABC, abstractmethod
+
+from airflow.operators.bash_operator import BashOperator
+from airflow.models import Variable
+from kubernetes.client import models as k8s
+
+
+class AbstractOpenshiftInstaller(ABC):
+    def __init__(self, dag, version, release_stream, latest_release, platform, profile):
+        self.exec_config = {
+            "pod_override": k8s.V1Pod(
+                spec=k8s.V1PodSpec(
+                    containers=[
+                        k8s.V1Container(
+                            name="base",
+                            image="quay.io/keithwhitley4/airflow-ansible:2.0.0",
+                            image_pull_policy="Always",
+                            volume_mounts=[
+                                kubeconfig.get_empty_dir_volume_mount()]
+
+                        )
+                    ],
+                    volumes=[kubeconfig.get_empty_dir_volume_mount()]
+                )
+            )
+        }
+
+        # General DAG Configuration
+        self.dag = dag
+        self.platform = platform  # e.g. aws
+        self.version = version  # e.g. 4.6/4.7, major.minor only
+        # true release stream to follow. Nightlies, CI, etc.
+        self.release_stream = release_stream
+        self.latest_release = latest_release  # latest relase from the release stream
+        self.profile = profile  # e.g. default/ovn
+
+        # Specific Task Configuration
+        self.vars = var_loader.build_task_vars(
+            task="install", version=version, platform=platform, profile=profile)
+
+        # Airflow Variables
+        self.ansible_orchestrator = Variable.get(
+            "ansible_orchestrator", deserialize_json=True)
+
+        self.install_secrets = Variable.get(
+            f"openshift_install_config", deserialize_json=True)
+        self.aws_creds = Variable.get("aws_creds", deserialize_json=True)
+        self.gcp_creds = Variable.get("gcp_creds", deserialize_json=True)
+        self.azure_creds = Variable.get("azure_creds", deserialize_json=True)
+
+        # Merge all variables, prioritizing Airflow Secrets over git based vars
+        self.config = {
+            **self.vars,
+            **self.ansible_orchestrator,
+            **self.install_secrets,
+            **self.aws_creds,
+            **self.gcp_creds,
+            **self.azure_creds,
+            **self.latest_release,
+            **{ "es_server": var_loader.get_elastic_url() }
+        }
+        super().__init__()
+
+    @abstractmethod
+    def _get_task(self, operation="install", trigger_rule="all_success"):
+        raise NotImplementedError()
+    
+
+    def get_install_task(self):
+        indexer = StatusIndexer(self.dag, self.version, self.release_stream, self.latest_release, self.platform, self.profile, "install").get_index_task() 
+        install_task = self._get_task(operation="install")
+        install_task >> indexer 
+        return install_task
+
+    def get_cleanup_task(self):
+        # trigger_rule = "all_done" means this task will run when every other task has finished, whether it fails or succeededs
+        return self._get_task(operation="cleanup")    
+
+    def _setup_task(self, operation="install"):
+        self.config = {**self.config, **self._get_playbook_operations(operation)}
+        self.config['openshift_cluster_name'] = self._generate_cluster_name()
+        self.config['dynamic_deploy_path'] = f"{config['openshift_cluster_name']}"
+        self.config['kubeconfig_path'] = f"/root/{config['dynamic_deploy_path']}/auth/kubeconfig"
+        self.env = {
+            "SSHKEY_TOKEN": self.config['sshkey_token'],
+            "ORCHESTRATION_HOST": self.config['orchestration_host'],
+            "ORCHESTRATION_USER": self.config['orchestration_user'],
+            "OPENSHIFT_CLUSTER_NAME": self.config['openshift_cluster_name'],
+            "DEPLOY_PATH": self.config['dynamic_deploy_path'],
+            "KUBECONFIG_NAME": f"{self.version}-{self.platform}-{self.profile}-kubeconfig",
+            "KUBEADMIN_NAME": f"{self.version}-{self.platform}-{self.profile}-kubeadmin",
+            **self._insert_kube_env()
+        }
+
+        # Dump all vars to json file for Ansible to pick up
+        with open(f"/tmp/{self.version}-{self.platform}-{self.profile}-{operation}-task.json", 'w') as json_file:
+            json.dump(config, json_file, sort_keys=True, indent=4)   
+
+    def _generate_cluster_name(self):
+        git_user = var_loader.get_git_user()
+        if git_user == 'cloud-bulldozer':
+            return f"ci-{self.version}-{self.platform}-{self.profile}"
+        else: 
+            return f"{git_user}-{self.version}-{self.platform}-{self.profile}"
+
+    def _get_playbook_operations(self, operation):
+        if operation == "install":
+            return {"openshift_cleanup": True, "openshift_debug_config": False,
+                                   "openshift_install": True, "openshift_post_config": True, "openshift_post_install": True}
+        else:
+            return {"openshift_cleanup": True, "openshift_debug_config": False,
+                                   "openshift_install": False, "openshift_post_config": False, "openshift_post_install": False}
+    
+    # This Helper Injects Airflow environment variables into the task execution runtime
+    # This allows the task to interface with the Kubernetes cluster Airflow is hosted on.
+    def _insert_kube_env(self):
+        return {key: value for (key, value) in environ.items() if "KUBERNETES" in key}

--- a/dags/openshift_nightlies/tasks/install/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/openshift.py
@@ -106,7 +106,7 @@ class AbstractOpenshiftInstaller(ABC):
 
         # Dump all vars to json file for Ansible to pick up
         with open(f"/tmp/{self.version}-{self.platform}-{self.profile}-{operation}-task.json", 'w') as json_file:
-            json.dump(config, json_file, sort_keys=True, indent=4)   
+            json.dump(self.config, json_file, sort_keys=True, indent=4)   
 
     def _generate_cluster_name(self):
         git_user = var_loader.get_git_user()

--- a/dags/openshift_nightlies/tasks/install/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/openshift.py
@@ -91,8 +91,8 @@ class AbstractOpenshiftInstaller(ABC):
     def _setup_task(self, operation="install"):
         self.config = {**self.config, **self._get_playbook_operations(operation)}
         self.config['openshift_cluster_name'] = self._generate_cluster_name()
-        self.config['dynamic_deploy_path'] = f"{config['openshift_cluster_name']}"
-        self.config['kubeconfig_path'] = f"/root/{config['dynamic_deploy_path']}/auth/kubeconfig"
+        self.config['dynamic_deploy_path'] = f"{self.config['openshift_cluster_name']}"
+        self.config['kubeconfig_path'] = f"/root/{self.config['dynamic_deploy_path']}/auth/kubeconfig"
         self.env = {
             "SSHKEY_TOKEN": self.config['sshkey_token'],
             "ORCHESTRATION_HOST": self.config['orchestration_host'],

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 set -a
+
+install_argo_cli(){
+    VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+    curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-linux-amd64
+    chmod +x /usr/local/bin/argocd
+}
+
 output_info() {
     _argo_url=$(oc get route/argocd -o jsonpath='{.spec.host}' -n argocd)
     _argo_user="admin"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,12 +33,6 @@ install_argo(){
 
 }
 
-install_argo_cli(){
-    VERSION=$(curl --silent "https://api.github.com/repos/argoproj/argo-cd/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-    curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/download/$VERSION/argocd-linux-amd64
-    chmod +x /usr/local/bin/argocd
-}
-
 pre_install(){
     kubectl create namespace argocd || true
     kubectl create namespace fluentd || true

--- a/scripts/playground/build.sh
+++ b/scripts/playground/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -a
+usage() { echo "Usage: $0 [-p <string> (airflow password)]" 1>&2; exit 1; }
+GIT_ROOT=$(git rev-parse --show-toplevel)
+source $GIT_ROOT/scripts/common.sh
+_remote_origin_url=$(git config --get remote.origin.url)
+_remote_user=$(git config --get remote.origin.url | cut -d'/' -f4)
+_airflow_namespace=$_remote_user-airflow
+_branch=$(git branch --show-current)
+_cluster_domain=$(oc get ingresses.config.openshift.io/cluster -o jsonpath='{.spec.domain}')
+
+
+while getopts p: flag
+do
+    case "${flag}" in
+        p) password=${OPTARG};;
+        *) usage;;
+    esac
+done
+
+if [[ -z "$password" ]]; then 
+    usage
+fi
+
+
+kubectl create namespace $_airflow_namespace || true
+envsubst < $GIT_ROOT/scripts/playground/templates/airflow.yaml | kubectl apply -f -

--- a/scripts/playground/cleanup.sh
+++ b/scripts/playground/cleanup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -a
+usage() { echo "Usage: $0 [-p <string> (airflow password)]" 1>&2; exit 1; }
+GIT_ROOT=$(git rev-parse --show-toplevel)
+source $GIT_ROOT/scripts/common.sh
+_remote_origin_url=$(git config --get remote.origin.url)
+_remote_user=$(git config --get remote.origin.url | cut -d'/' -f4)
+_airflow_namespace=$_remote_user-airflow
+_branch=$(git branch --show-current)
+_cluster_domain=$(oc get ingresses.config.openshift.io/cluster -o jsonpath='{.spec.domain}')
+
+
+
+envsubst < $GIT_ROOT/scripts/playground/templates/airflow.yaml | kubectl delete -f -
+kubectl delete namespace $_airflow_namespace || true

--- a/scripts/playground/templates/airflow.yaml
+++ b/scripts/playground/templates/airflow.yaml
@@ -1,0 +1,147 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: $_remote_user-airflow
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  destination: 
+    namespace: $_airflow_namespace
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: $_remote_origin_url
+    path: charts/airflow
+    targetRevision: $_branch
+    helm:
+      releaseName: airflow
+      values: |-
+        defaultAirflowTag: 2.0.2
+        config:
+          logging:
+            colored_console_log: "True"
+            remote_logging: "True"
+          elasticsearch:
+            write_stdout: "True"
+          elasticsearch_configs:
+            use_ssl: "False"
+            verify_certs: "False"
+            ssl_show_warn: "False"
+          kubernetes:
+            delete_worker_pods: True
+          core:
+            DAGBAG_IMPORT_TIMEOUT: 300
+            killed_task_cleanup_time: 604800
+          scheduler:
+            scheduler_heartbeat_sec: 10
+            processor_poll_interval: 30
+        dags:
+          gitSync:
+            enabled: true
+            subPath: dags
+            depth: 8
+        elasticsearch:
+          enabled: True
+          connection: 
+            host: logging-es-http.openshift-logging.svc.cluster.local
+            port: 9200
+            user: ""
+            pass: ""
+        webserver:
+          replicas: 1
+          defaultUser:
+            password: $password
+        env:
+        - name: AIRFLOW__KUBERNETES__DAGS_VOLUME_SUBPATH
+          value: repo/
+        - name: AIRFLOW__CORE__KILLED_TASK_CLEANUP_TIME
+          value: 604800
+        - name: GIT_REPO
+          value: $_remote_origin_url
+        - name: GIT_BRANCH
+          value: $_branch      
+      parameters:
+      - name: dags.gitSync.repo
+        value: $_remote_origin_url
+      - name: dags.gitSync.branch
+        value: $_branch
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: airflow
+  namespace: $_airflow_namespace
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  host: $_airflow_namespace.$_cluster_domain
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: airflow-webserver
+    weight: 100
+  wildcardPolicy: None
+--- 
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: $_remote_user-pod-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# This cluster role binding allows anyone in the "manager" group to read secrets in any namespace.
+kind: ClusterRoleBinding
+metadata:
+  name: $_remote_user-pod-reader
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+subjects:
+- kind: ServiceAccount
+  name: airflow-webserver # Name is case sensitive
+  namespace: $_airflow_namespace
+- kind: ServiceAccount
+  name: airflow-worker # Name is case sensitive
+  namespace: $_airflow_namespace
+roleRef:
+  kind: ClusterRole
+  name: $_remote_user-pod-reader
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: airflow-worker
+  namespace: $_airflow_namespace
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["secrets", "configmaps", "pods"]
+  verbs:  ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: airflow-worker
+  namespace: $_airflow_namespace
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+subjects:
+- kind: ServiceAccount
+  name: airflow-worker
+  namespace: $_airflow_namespace
+roleRef:
+  kind: Role
+  name: airflow-worker
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Implements base class for install tasks and adds support for developer playground

this pr only changes the cloud installer to use the ABC. A separate PR will need to be added to support baremetal.

relevant dag: http://whitleykeith-airflow.apps.keith-cluster.perfscale.devcluster.openshift.com/graph?dag_id=4.6_aws_default