### PR TITLE
Qol updates

### DIFF
--- a/charts/perfscale/templates/airflow.yaml
+++ b/charts/perfscale/templates/airflow.yaml
@@ -36,8 +36,6 @@ spec:
         value: {{ .Values.global.repo.url }}
       - name: dags.gitSync.branch
         value: {{ .Values.global.repo.branch }}
-      - name: config.elasticsearch.frontend
-        value: logging-kibana.{{ .Values.global.baseDomain }}/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30m,to:now))&_a=(columns:!(message),filters:!(),index:a16f10f0-cf86-11eb-a0b9-a32be872b9a2,interval:auto,query:(language:kuery,query:'log_id:{log_id}'),sort:!())
   syncPolicy:
     automated:
       prune: true

--- a/dags/openshift_nightlies/dag.py
+++ b/dags/openshift_nightlies/dag.py
@@ -70,11 +70,6 @@ class AbstractOpenshiftNightlyDAG(ABC):
 
 
 class CloudOpenshiftNightlyDAG(AbstractOpenshiftNightlyDAG):
-    def __init__(self, release: OpenshiftRelease, config: DagConfig):
-        super().__init__(self, release, config)
-        self.release_stream_base_url = Variable.get("release_stream_base_url")
-        self.latest_release = var_loader.get_latest_release_from_stream(self.release_stream_base_url, self.release.release_stream)
-    
     def build(self):
         installer = self._get_openshift_installer()
         install_cluster = installer.get_install_task()
@@ -95,10 +90,7 @@ class CloudOpenshiftNightlyDAG(AbstractOpenshiftNightlyDAG):
 
 
 
-class BaremetalOpenshiftNightlyDAG(AbstractOpenshiftNightlyDAG):
-    def __init__(self, release: BaremetalRelease, config: DagConfig):
-        super().__init__(release, config)
-        
+class BaremetalOpenshiftNightlyDAG(AbstractOpenshiftNightlyDAG):   
     def build(self):
         bm_installer = self._get_openshift_installer()
         install_cluster = bm_installer.get_install_task()
@@ -111,11 +103,6 @@ class BaremetalOpenshiftNightlyDAG(AbstractOpenshiftNightlyDAG):
 
 
 class OpenstackNightlyDAG(AbstractOpenshiftNightlyDAG):
-    def __init__(self, release: OpenshiftRelease, config: DagConfig):
-        super().__init__(release, config)
-        self.release_stream_base_url = Variable.get("release_stream_base_url")
-        self.latest_release = var_loader.get_latest_release_from_stream(self.release_stream_base_url, self.release.release_stream)
-
     def build(self):
         installer = self._get_openshift_installer()
         install_cluster = installer.get_install_task()

--- a/dags/openshift_nightlies/dag.py
+++ b/dags/openshift_nightlies/dag.py
@@ -71,7 +71,7 @@ class AbstractOpenshiftNightlyDAG(ABC):
 
 class CloudOpenshiftNightlyDAG(AbstractOpenshiftNightlyDAG):
     def __init__(self, release: OpenshiftRelease, config: DagConfig):
-        super().__init__(self, release: OpenshiftRelease, config: DagConfig)
+        super().__init__(self, release, config)
         self.release_stream_base_url = Variable.get("release_stream_base_url")
         self.latest_release = var_loader.get_latest_release_from_stream(self.release_stream_base_url, self.release.release_stream)
     

--- a/dags/openshift_nightlies/dag.py
+++ b/dags/openshift_nightlies/dag.py
@@ -98,7 +98,7 @@ class BaremetalOpenshiftNightlyDAG(AbstractOpenshiftNightlyDAG):
         install_cluster >> scaleup_cluster
 
     def _get_openshift_installer(self):
-        return jetski.BaremetalOpenshiftInstaller(self.dag, release)
+        return jetski.BaremetalOpenshiftInstaller(self.dag, self.release)
 
 
 
@@ -115,7 +115,7 @@ class OpenstackNightlyDAG(AbstractOpenshiftNightlyDAG):
         install_cluster >> benchmarks
 
     def _get_openshift_installer(self):
-        return jetpack.OpenstackJetpackInstaller(self.dag, release)
+        return jetpack.OpenstackJetpackInstaller(self.dag, self.release)
 
 
 

--- a/dags/openshift_nightlies/dag.py
+++ b/dags/openshift_nightlies/dag.py
@@ -109,7 +109,6 @@ class OpenstackNightlyDAG(AbstractOpenshiftNightlyDAG):
     def build(self):
         installer = self._get_openshift_installer()
         install_cluster = installer.get_install_task()
-        cleanup_cluster = installer.get_cleanup_task()
         with TaskGroup("benchmarks", prefix_group_id=False, dag=self.dag) as benchmarks:
             benchmark_tasks = self._get_e2e_benchmarks().get_benchmarks()
             chain(*benchmark_tasks)

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -6,10 +6,12 @@ versionAliases:
   - version: 4.9
     alias: future
 
-schedules:
-  enabled: true
-  default: "0 12 * * 1,3,5"
-  openstack: "0 12 * * 1-6"
+dagConfig:
+  schedules:
+    enabled: true
+    default: "0 12 * * 1,3,5"
+    openstack: "0 12 * * 1-6"
+  cleanupOnSuccess: true
 
 platforms:
   cloud:

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -11,7 +11,7 @@ dagConfig:
     enabled: true
     default: "0 12 * * 1,3,5"
     openstack: "0 12 * * 1-6"
-  cleanupOnSuccess: false
+  cleanupOnSuccess: true
 
 platforms:
   cloud:

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -6,6 +6,11 @@ versionAliases:
   - version: 4.9
     alias: future
 
+schedules:
+  enabled: true
+  default: "0 12 * * 1,3,5"
+  openstack: "0 12 * * 1-6"
+
 platforms:
   cloud:
     - version: 4.8

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -11,7 +11,7 @@ dagConfig:
     enabled: true
     default: "0 12 * * 1,3,5"
     openstack: "0 12 * * 1-6"
-  cleanupOnSuccess: true
+  cleanupOnSuccess: false
 
 platforms:
   cloud:

--- a/dags/openshift_nightlies/models/dag_config.py
+++ b/dags/openshift_nightlies/models/dag_config.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from datetime import timedelta, datetime
+
+@dataclass
+class DagConfig:
+    schedule_interval: Optional[str] = None
+    default_args: Optional[dict] = {
+            'owner': 'airflow',
+            'depends_on_past': False,
+            'start_date': datetime(2021, 1, 1),
+            'email': ['airflow@example.com'],
+            'email_on_failure': False,
+            'email_on_retry': False,
+            'retries': 1,
+            'retry_delay': timedelta(minutes=5)
+        }

--- a/dags/openshift_nightlies/models/dag_config.py
+++ b/dags/openshift_nightlies/models/dag_config.py
@@ -7,6 +7,7 @@ from datetime import timedelta, datetime
 @dataclass
 class DagConfig:
     schedule_interval: Optional[str] = None
+    cleanup_on_success: Optional[bool] = True
     default_args: Optional[dict] = field(default_factory=lambda: {
             'owner': 'airflow',
             'depends_on_past': False,

--- a/dags/openshift_nightlies/models/dag_config.py
+++ b/dags/openshift_nightlies/models/dag_config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 from datetime import timedelta, datetime
 
 @dataclass

--- a/dags/openshift_nightlies/models/dag_config.py
+++ b/dags/openshift_nightlies/models/dag_config.py
@@ -1,13 +1,13 @@
 import sys
 from os.path import abspath, dirname
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 from datetime import timedelta, datetime
 
 @dataclass
 class DagConfig:
     schedule_interval: Optional[str] = None
-    default_args: Optional[dict] = {
+    default_args: Optional[dict] = field(default_factory= lambda: {
             'owner': 'airflow',
             'depends_on_past': False,
             'start_date': datetime(2021, 1, 1),
@@ -16,4 +16,4 @@ class DagConfig:
             'email_on_retry': False,
             'retries': 1,
             'retry_delay': timedelta(minutes=5)
-        }
+        })

--- a/dags/openshift_nightlies/models/dag_config.py
+++ b/dags/openshift_nightlies/models/dag_config.py
@@ -7,7 +7,7 @@ from datetime import timedelta, datetime
 @dataclass
 class DagConfig:
     schedule_interval: Optional[str] = None
-    default_args: Optional[dict] = field(default_factory= lambda: {
+    default_args: Optional[dict] = field(default_factory=lambda: {
             'owner': 'airflow',
             'depends_on_past': False,
             'start_date': datetime(2021, 1, 1),

--- a/dags/openshift_nightlies/models/dag_config.py
+++ b/dags/openshift_nightlies/models/dag_config.py
@@ -1,3 +1,5 @@
+import sys
+from os.path import abspath, dirname
 from dataclasses import dataclass
 from typing import Optional
 from datetime import timedelta, datetime

--- a/dags/openshift_nightlies/models/release.py
+++ b/dags/openshift_nightlies/models/release.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+sys.path.insert(0, dirname(abspath(dirname(__file__))))
+from utils import var_loader
+
+@dataclass
+class OpenshiftRelease:
+    """Class used to define a unique release"""
+    platform: str  # e.g. aws
+    version: str # e.g. 4.7
+    release_stream: str # The actual release stream to pull from (nightly/stable/ci)
+    profile: str # e.g. default/ovn
+    version_alias: Optional[str] # e.g. stable/.next/.future
+
+    def get_release_name(self) -> str: 
+        return f"{self.version}_{self.platform}_{self.profile}"
+    
+    def get_release_name(self, delimiter) -> str:
+        return f"{self.version}{delimiter}{self.platform}{delimiter}{self.profile}"
+
+    def get_latest_release(self) -> dict: 
+        return var_loader.get_latest_release_from_stream(self.release_stream)
+
+@dataclass
+class BaremetalRelease(OpenshiftRelease):
+    """Class for baremetal releases as it needs a build field"""
+    build: str
+
+    # Baremetal doesn't get it's release from a release stream
+    def get_latest_release(self) -> dict:
+        return {}
+
+
+

--- a/dags/openshift_nightlies/models/release.py
+++ b/dags/openshift_nightlies/models/release.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 sys.path.insert(0, dirname(abspath(dirname(__file__))))
 from utils import var_loader
 

--- a/dags/openshift_nightlies/models/release.py
+++ b/dags/openshift_nightlies/models/release.py
@@ -3,7 +3,7 @@ from os.path import abspath, dirname
 from dataclasses import dataclass
 from typing import Optional
 sys.path.insert(0, dirname(abspath(dirname(__file__))))
-from utils import var_loader
+from util import var_loader
 
 @dataclass
 class OpenshiftRelease:

--- a/dags/openshift_nightlies/models/release.py
+++ b/dags/openshift_nightlies/models/release.py
@@ -12,11 +12,8 @@ class OpenshiftRelease:
     release_stream: str # The actual release stream to pull from (nightly/stable/ci)
     profile: str # e.g. default/ovn
     version_alias: Optional[str] # e.g. stable/.next/.future
-
-    def get_release_name(self) -> str: 
-        return f"{self.version}_{self.platform}_{self.profile}"
     
-    def get_release_name(self, delimiter) -> str:
+    def get_release_name(self, delimiter="_") -> str:
         return f"{self.version}{delimiter}{self.platform}{delimiter}{self.profile}"
 
     def get_latest_release(self, base_url) -> dict: 

--- a/dags/openshift_nightlies/models/release.py
+++ b/dags/openshift_nightlies/models/release.py
@@ -34,7 +34,7 @@ class BaremetalRelease(OpenshiftRelease):
     build: str
 
     # Baremetal doesn't get it's release from a release stream
-    def get_latest_release(self) -> dict:
+    def get_latest_release(self, base_url) -> dict:
         return {}
 
 

--- a/dags/openshift_nightlies/models/release.py
+++ b/dags/openshift_nightlies/models/release.py
@@ -1,3 +1,5 @@
+import sys
+from os.path import abspath, dirname
 from dataclasses import dataclass
 from typing import Optional
 sys.path.insert(0, dirname(abspath(dirname(__file__))))

--- a/dags/openshift_nightlies/models/release.py
+++ b/dags/openshift_nightlies/models/release.py
@@ -1,4 +1,5 @@
 import sys
+import requests
 from os.path import abspath, dirname
 from dataclasses import dataclass
 from typing import Optional

--- a/dags/openshift_nightlies/models/release.py
+++ b/dags/openshift_nightlies/models/release.py
@@ -3,7 +3,6 @@ from os.path import abspath, dirname
 from dataclasses import dataclass
 from typing import Optional
 sys.path.insert(0, dirname(abspath(dirname(__file__))))
-from util import var_loader
 
 @dataclass
 class OpenshiftRelease:
@@ -20,8 +19,16 @@ class OpenshiftRelease:
     def get_release_name(self, delimiter) -> str:
         return f"{self.version}{delimiter}{self.platform}{delimiter}{self.profile}"
 
-    def get_latest_release(self) -> dict: 
-        return var_loader.get_latest_release_from_stream(self.release_stream)
+    def get_latest_release(self, base_url) -> dict: 
+        url = f"{base_url}/{self.release_stream}/latest"
+        payload = requests.get(url).json()
+        latest_accepted_release = payload["name"]
+        latest_accepted_release_url = payload["downloadURL"]
+        return {
+            "openshift_client_location": f"{latest_accepted_release_url}/openshift-client-linux-{latest_accepted_release}.tar.gz",
+            "openshift_install_binary_url": f"{latest_accepted_release_url}/openshift-install-linux-{latest_accepted_release}.tar.gz"
+        }
+    
 
 @dataclass
 class BaremetalRelease(OpenshiftRelease):

--- a/dags/openshift_nightlies/scripts/install/cloud.sh
+++ b/dags/openshift_nightlies/scripts/install/cloud.sh
@@ -20,7 +20,6 @@ setup(){
     git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
     export PUBLIC_KEY=/home/airflow/workspace/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
     export PRIVATE_KEY=/home/airflow/workspace/perf-dept/ssh_keys/id_rsa_pbench_ec2 
-    export ANSIBLE_FORCE_COLOR=true
     export AWS_REGION=us-west-2
     chmod 600 ${PRIVATE_KEY}
 

--- a/dags/openshift_nightlies/scripts/utils/run_scale_ci_diagnosis.sh
+++ b/dags/openshift_nightlies/scripts/utils/run_scale_ci_diagnosis.sh
@@ -23,8 +23,7 @@ setup(){
     export SNAPPY_RUN_ID=${AIRFLOW_CTX_DAG_ID}/${AIRFLOW_CTX_DAG_RUN_ID}
 
     
-    curl -L $OPENSHIFT_CLIENT_LOCATION -o openshift-client.tar.gz
-    tar -xzf openshift-client.tar.gz
+    curl -sS https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz oc
 
     export PATH=$PATH:$(pwd)
 

--- a/dags/openshift_nightlies/tasks/install/baremetal/jetski.py
+++ b/dags/openshift_nightlies/tasks/install/baremetal/jetski.py
@@ -5,6 +5,7 @@ from os import environ
 sys.path.insert(0, dirname(dirname(dirname(abspath(dirname(__file__))))))
 from util import var_loader, kubeconfig, constants
 from tasks.install.baremetal import webfuse
+from models.release import BaremetalRelease
 
 import json
 
@@ -13,41 +14,11 @@ from airflow.models import Variable
 from kubernetes.client import models as k8s
 
 # Defines Tasks for installation of Openshift Clusters
-class BaremetalOpenshiftInstaller():
-    def __init__(self, dag, version, release_stream, platform, profile, build):
-
-        self.exec_config = {
-            "pod_override": k8s.V1Pod(
-                spec=k8s.V1PodSpec(
-                    containers=[
-                        k8s.V1Container(
-                            name="base",
-                            image="quay.io/mukrishn/jetski:2.0",
-                            image_pull_policy="Always",
-                            volume_mounts=[
-                                kubeconfig.get_empty_dir_volume_mount()]
-
-                        )
-                    ],
-                    volumes=[kubeconfig.get_empty_dir_volume_mount()]
-                )
-            )
-        }
-
-        # General DAG Configuration
-        self.dag = dag
-        self.platform = platform  # e.g. aws
-        self.version = version  # e.g. 4.6/4.7, major.minor only
-        self.openshift_release = release_stream # true release stream to follow. Nightlies, CI, etc. 
-        self.profile = profile  # e.g. default/ovn
-        self.openshift_build = build
-
-        # Specific Task Configuration
-        self.vars = var_loader.build_task_vars(
-            task="install", version=version, platform=platform, profile=profile)
-       
-        self.install_secrets = Variable.get(
+class BaremetalOpenshiftInstaller(AbstractOpenshiftInstaller):
+    def __init__(self, dag, release: BaremetalRelease):
+        self.baremetal_install_secrets = Variable.get(
             f"baremetal_openshift_install_config", deserialize_json=True)
+        super().__init__(dag, release)
 
     def get_install_task(self):
         webfuse_installer = self._get_webfuse_installer()
@@ -62,7 +33,7 @@ class BaremetalOpenshiftInstaller():
         return self._get_task(operation="scaleup")
 
     def _get_webfuse_installer(self):
-        return webfuse.BaremetalWebfuseInstaller(self.dag, self.version, self.openshift_release, self.platform, self.profile, self.openshift_build)
+        return webfuse.BaremetalWebfuseInstaller(self.dag, self.release)
 
     # Create Airflow Task for Install/Cleanup steps
     def _get_task(self, operation="install", trigger_rule="all_success"):
@@ -71,13 +42,13 @@ class BaremetalOpenshiftInstaller():
         # Merge all variables, prioritizing Airflow Secrets over git based vars
         config = {
             **self.vars,
-            **self.install_secrets,
+            **self.baremetal_install_secrets,
             **{ "es_server": var_loader.get_elastic_url() }
         }
         
         config['pullsecret'] = json.dumps(config['openshift_install_pull_secret'])
         config['version'] = config['openshift_release']
-        config['build'] = config['openshift_build']
+        config['build'] = self.release.build
         
         # Required Environment Variables for Install script
         env = {
@@ -98,21 +69,16 @@ class BaremetalOpenshiftInstaller():
             bash_script = f"{constants.root_dag_dir}/scripts/install/baremetal_scaleup.sh"
 
         # Dump all vars to json file for Ansible to pick up
-        with open(f"/tmp/{self.version}-{self.platform}-{self.profile}-{operation}-task.json", 'w') as json_file:
+        with open(f"/tmp/{self.release_name}-{operation}-task.json", 'w') as json_file:
             json.dump(config, json_file, sort_keys=True, indent=4)
 
         return BashOperator(
             task_id=f"{operation}-cluster",
             depends_on_past=False,
-            bash_command=f"{bash_script} -p {self.platform} -v {self.version} -j /tmp/{self.version}-{self.platform}-{self.profile}-{operation}-task.json -o {operation} ",
+            bash_command=f"{bash_script} -p {self.release.platform} -v {self.release.version} -j /tmp/{self.release_name}-{operation}-task.json -o {operation} ",
             retries=3,
             dag=self.dag,
             trigger_rule=trigger_rule,
             executor_config=self.exec_config,
             env=env
         )
-
-    # This Helper Injects Airflow environment variables into the task execution runtime
-    # This allows the task to interface with the Kubernetes cluster Airflow is hosted on.
-    def _insert_kube_env(self):
-        return {key: value for (key, value) in environ.items() if "KUBERNETES" in key}

--- a/dags/openshift_nightlies/tasks/install/baremetal/jetski.py
+++ b/dags/openshift_nightlies/tasks/install/baremetal/jetski.py
@@ -5,6 +5,7 @@ from os import environ
 sys.path.insert(0, dirname(dirname(dirname(abspath(dirname(__file__))))))
 from util import var_loader, kubeconfig, constants
 from tasks.install.baremetal import webfuse
+from tasks.install.openshift import AbstractOpenshiftInstaller
 from models.release import BaremetalRelease
 
 import json

--- a/dags/openshift_nightlies/tasks/install/baremetal/webfuse.py
+++ b/dags/openshift_nightlies/tasks/install/baremetal/webfuse.py
@@ -4,6 +4,7 @@ from os import environ
 
 sys.path.insert(0, dirname(dirname(dirname(abspath(dirname(__file__))))))
 from util import var_loader, kubeconfig, constants
+from models.release import BaremetalRelease
 
 import json
 
@@ -12,41 +13,11 @@ from airflow.models import Variable
 from kubernetes.client import models as k8s
 
 # Defines Tasks for installation of Openshift Clusters
-class BaremetalWebfuseInstaller():
-    def __init__(self, dag, version, release_stream, platform, profile, build):
-
-        self.exec_config = {
-            "pod_override": k8s.V1Pod(
-                spec=k8s.V1PodSpec(
-                    containers=[
-                        k8s.V1Container(
-                            name="base",
-                            image="quay.io/mukrishn/jetski:2.0",
-                            image_pull_policy="Always",
-                            volume_mounts=[
-                                kubeconfig.get_empty_dir_volume_mount()]
-
-                        )
-                    ],
-                    volumes=[kubeconfig.get_empty_dir_volume_mount()]
-                )
-            )
-        }
-
-        # General DAG Configuration
-        self.dag = dag
-        self.platform = platform  # e.g. aws
-        self.version = version  # e.g. 4.6/4.7, major.minor only
-        self.openshift_release = release_stream # true release stream to follow. Nightlies, CI, etc. 
-        self.profile = profile  # e.g. default/ovn
-        self.openshift_build = build
-
-        # Specific Task Configuration
-        self.vars = var_loader.build_task_vars(
-            task="install", version=version, platform=platform, profile=profile)
-       
-        self.install_secrets = Variable.get(
+class BaremetalWebfuseInstaller(AbstractOpenshiftInstaller):
+    def __init__(self, dag, release: BaremetalRelease):       
+        self.baremetal_install_secrets = Variable.get(
             f"baremetal_openshift_install_config", deserialize_json=True)
+        super().__init__(dag, release)
 
     def get_deploy_app_task(self):
         return self._get_task()        
@@ -58,12 +29,12 @@ class BaremetalWebfuseInstaller():
         # Merge all variables, prioritizing Airflow Secrets over git based vars
         config = {
             **self.vars,
-            **self.install_secrets,
+            **self.baremetal_install_secrets,
             **{ "es_server": var_loader.get_elastic_url() }
         }
         
         config['version'] = config['openshift_release']
-        config['build'] = config['openshift_build']
+        config['build'] = self.release.build
         
         # Required Environment Variables for Install script
         env = {
@@ -77,13 +48,13 @@ class BaremetalWebfuseInstaller():
 
 
         # Dump all vars to json file for Ansible to pick up
-        with open(f"/tmp/{self.version}-{self.platform}-{self.profile}-task.json", 'w') as json_file:
+        with open(f"/tmp/{self.release_name}-task.json", 'w') as json_file:
             json.dump(config, json_file, sort_keys=True, indent=4)
 
         return BashOperator(
             task_id="deploy-webfuse",
             depends_on_past=False,
-            bash_command=f"{bash_script} -p {self.platform} -v {self.version} -j /tmp/{self.version}-{self.platform}-{self.profile}-task.json -o deploy_app ",
+            bash_command=f"{bash_script} -p {self.release.platform} -v {self.release.version} -j /tmp/{self.release_name}-task.json -o deploy_app ",
             retries=3,
             dag=self.dag,
             trigger_rule=trigger_rule,

--- a/dags/openshift_nightlies/tasks/install/baremetal/webfuse.py
+++ b/dags/openshift_nightlies/tasks/install/baremetal/webfuse.py
@@ -5,6 +5,7 @@ from os import environ
 sys.path.insert(0, dirname(dirname(dirname(abspath(dirname(__file__))))))
 from util import var_loader, kubeconfig, constants
 from models.release import BaremetalRelease
+from tasks.install.openshift import AbstractOpenshiftInstaller
 
 import json
 

--- a/dags/openshift_nightlies/tasks/install/cloud/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/cloud/openshift.py
@@ -22,7 +22,7 @@ class CloudOpenshiftInstaller(AbstractOpenshiftInstaller):
         return BashOperator(
             task_id=f"{operation}",
             depends_on_past=False,
-            bash_command=f"{constants.root_dag_dir}/scripts/install/cloud.sh -p {self.platform} -v {self.version} -j /tmp/{self.version}-{self.platform}-{self.profile}-{operation}-task.json -o {operation}",
+            bash_command=f"{constants.root_dag_dir}/scripts/install/cloud.sh -p {self.release.platform} -v {self.release.version} -j /tmp/{self.release_name}-{operation}-task.json -o {operation}",
             retries=3,
             dag=self.dag,
             trigger_rule=trigger_rule,

--- a/dags/openshift_nightlies/tasks/install/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/openshift.py
@@ -7,6 +7,7 @@ from os import environ
 sys.path.insert(0, dirname(dirname(abspath(dirname(__file__)))))
 from util import var_loader, kubeconfig, constants
 from tasks.index.status import StatusIndexer
+from models.release import OpenshiftRelease
 
 import json
 import requests
@@ -18,21 +19,17 @@ from kubernetes.client import models as k8s
 
 
 class AbstractOpenshiftInstaller(ABC):
-    def __init__(self, dag, version, release_stream, latest_release, platform, profile):
+    def __init__(self, dag, release: OpenshiftRelease):
         self.exec_config = var_loader.get_default_executor_config()
 
         # General DAG Configuration
         self.dag = dag
-        self.platform = platform  # e.g. aws
-        self.version = version  # e.g. 4.6/4.7, major.minor only
-        # true release stream to follow. Nightlies, CI, etc.
-        self.release_stream = release_stream
-        self.latest_release = latest_release  # latest relase from the release stream
-        self.profile = profile  # e.g. default/ovn
+        self.release = release
+        self.release_name = release.get_release_name(delimiter="-")
 
         # Specific Task Configuration
         self.vars = var_loader.build_task_vars(
-            task="install", version=version, platform=platform, profile=profile)
+            release, task="install")
 
         # Airflow Variables
         self.ansible_orchestrator = Variable.get(
@@ -55,7 +52,7 @@ class AbstractOpenshiftInstaller(ABC):
             **self.gcp_creds,
             **self.azure_creds,
             **self.openstack_creds,
-            **self.latest_release,
+            **self.release.get_latest_release(),
             **{ "es_server": var_loader.get_elastic_url() }
         }
         super().__init__()
@@ -66,7 +63,7 @@ class AbstractOpenshiftInstaller(ABC):
     
 
     def get_install_task(self):
-        indexer = StatusIndexer(self.dag, self.version, self.release_stream, self.platform, self.profile, "install").get_index_task() 
+        indexer = StatusIndexer(self.dag, self.release, "install").get_index_task() 
         install_task = self._get_task(operation="install")
         install_task >> indexer 
         return install_task
@@ -86,22 +83,22 @@ class AbstractOpenshiftInstaller(ABC):
             "ORCHESTRATION_USER": self.config['orchestration_user'],
             "OPENSHIFT_CLUSTER_NAME": self.config['openshift_cluster_name'],
             "DEPLOY_PATH": self.config['dynamic_deploy_path'],
-            "KUBECONFIG_NAME": f"{self.version}-{self.platform}-{self.profile}-kubeconfig",
-            "KUBEADMIN_NAME": f"{self.version}-{self.platform}-{self.profile}-kubeadmin",
+            "KUBECONFIG_NAME": f"{self.release_name}-kubeconfig",
+            "KUBEADMIN_NAME": f"{self.release_name}-kubeadmin",
             "OPENSHIFT_INSTALL_PULL_SECRET": self.ocp_pull_secret,
             **self._insert_kube_env()
         }
 
         # Dump all vars to json file for Ansible to pick up
-        with open(f"/tmp/{self.version}-{self.platform}-{self.profile}-{operation}-task.json", 'w') as json_file:
+        with open(f"/tmp/{self.release_name}-{operation}-task.json", 'w') as json_file:
             json.dump(self.config, json_file, sort_keys=True, indent=4)   
 
     def _generate_cluster_name(self):
         git_user = var_loader.get_git_user()
         if git_user == 'cloud-bulldozer':
-            return f"ci-{self.version}-{self.platform}-{self.profile}"
+            return f"ci-{self.release_name}"
         else: 
-            return f"{git_user}-{self.version}-{self.platform}-{self.profile}"
+            return f"{git_user}-{self.release_name}"
 
     def _get_playbook_operations(self, operation):
         if operation == "install":

--- a/dags/openshift_nightlies/tasks/install/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/openshift.py
@@ -42,6 +42,7 @@ class AbstractOpenshiftInstaller(ABC):
         self.azure_creds = Variable.get("azure_creds", deserialize_json=True)
         self.ocp_pull_secret = Variable.get("osp_ocp_pull_creds")
         self.openstack_creds = Variable.get("openstack_creds", deserialize_json=True)
+        self.release_stream_base_url = Variable.get("release_stream_base_url")
 
         # Merge all variables, prioritizing Airflow Secrets over git based vars
         self.config = {
@@ -52,7 +53,7 @@ class AbstractOpenshiftInstaller(ABC):
             **self.gcp_creds,
             **self.azure_creds,
             **self.openstack_creds,
-            **self.release.get_latest_release(),
+            **self.release.get_latest_release(self.release_stream_base_url),
             **{ "es_server": var_loader.get_elastic_url() }
         }
         super().__init__()

--- a/dags/openshift_nightlies/tasks/install/openstack/jetpack.py
+++ b/dags/openshift_nightlies/tasks/install/openstack/jetpack.py
@@ -21,7 +21,7 @@ class OpenstackJetpackInstaller(AbstractOpenshiftInstaller):
         return BashOperator(
             task_id=f"{operation}",
             depends_on_past=False,
-            bash_command=f"{constants.root_dag_dir}/scripts/install/jetpack.sh -j /tmp/{self.version}-{self.platform}-{self.profile}-{operation}-task.json -o {operation}",
+            bash_command=f"{constants.root_dag_dir}/scripts/install/jetpack.sh -j /tmp/{self.release_name}-{operation}-task.json -o {operation}",
             retries=3,
             dag=self.dag,
             trigger_rule=trigger_rule,
@@ -40,13 +40,13 @@ class OpenstackJetpackInstaller(AbstractOpenshiftInstaller):
             "ORCHESTRATION_USER": self.config['osp_orchestration_user'],
             "OPENSHIFT_CLUSTER_NAME": self.config['openshift_cluster_name'],
             "DEPLOY_PATH": self.config['dynamic_deploy_path'],
-            "KUBECONFIG_NAME": f"{self.version}-{self.platform}-{self.profile}-kubeconfig",
-            "KUBEADMIN_NAME": f"{self.version}-{self.platform}-{self.profile}-kubeadmin",
+            "KUBECONFIG_NAME": f"{self.release_name}-kubeconfig",
+            "KUBEADMIN_NAME": f"{self.release_name}-kubeadmin",
             "OPENSHIFT_INSTALL_PULL_SECRET": self.ocp_pull_secret,
             **self._insert_kube_env()
         }
 
         # Dump all vars to json file for Ansible to pick up
-        with open(f"/tmp/{self.version}-{self.platform}-{self.profile}-{operation}-task.json", 'w') as json_file:
+        with open(f"/tmp/{self.release_name}-{operation}-task.json", 'w') as json_file:
             json.dump(self.config, json_file, sort_keys=True, indent=4)   
 

--- a/dags/openshift_nightlies/util/kubeconfig.py
+++ b/dags/openshift_nightlies/util/kubeconfig.py
@@ -1,5 +1,6 @@
 import sys
-from os.path import abspath, dirname, environ
+from os.path import abspath, dirname
+from os import environ
 from kubernetes.client import models as k8s
 sys.path.insert(0, dirname(abspath(dirname(__file__))))
 from models.release import OpenshiftRelease

--- a/dags/openshift_nightlies/util/kubeconfig.py
+++ b/dags/openshift_nightlies/util/kubeconfig.py
@@ -1,5 +1,5 @@
 import sys
-from os import environ
+from os.path import abspath, dirname, environ
 from kubernetes.client import models as k8s
 sys.path.insert(0, dirname(abspath(dirname(__file__))))
 from models.release import OpenshiftRelease

--- a/dags/openshift_nightlies/util/kubeconfig.py
+++ b/dags/openshift_nightlies/util/kubeconfig.py
@@ -1,3 +1,4 @@
+import sys
 from os import environ
 from kubernetes.client import models as k8s
 sys.path.insert(0, dirname(abspath(dirname(__file__))))

--- a/dags/openshift_nightlies/util/kubeconfig.py
+++ b/dags/openshift_nightlies/util/kubeconfig.py
@@ -1,24 +1,26 @@
 from os import environ
 from kubernetes.client import models as k8s
+sys.path.insert(0, dirname(abspath(dirname(__file__))))
+from models.release import OpenshiftRelease
 
 
 
-def get_kubeadmin_password(version, platform, profile): 
+def get_kubeadmin_password(release: OpenshiftRelease): 
     return k8s.V1EnvVar(
         name="KUBEADMIN_PASSWORD",
         value_from=k8s.V1EnvVarSource(
             secret_key_ref= k8s.V1SecretKeySelector(
-                name=f"{version}-{platform}-{profile}-kubeadmin",
+                name=f"{release.version}-{release.platform}-{release.profile}-kubeadmin",
                 key="KUBEADMIN_PASSWORD"
             )
         )
     )
 
-def get_kubeconfig_volume(version, platform, profile):
+def get_kubeconfig_volume(release: OpenshiftRelease):
     return k8s.V1Volume(
         name="kubeconfig",
         secret=k8s.V1SecretVolumeSource(
-            secret_name=f"{version}-{platform}-{profile}-kubeconfig"
+            secret_name=f"{release.version}-{release.platform}-{release.profile}-kubeconfig"
         )
     )
 

--- a/dags/openshift_nightlies/util/manifest.py
+++ b/dags/openshift_nightlies/util/manifest.py
@@ -20,6 +20,7 @@ class Manifest():
             version_number = version['version']
             release_stream = version['releaseStream']
             version_alias = self.get_version_alias(version_number)
+            schedule = self._get_schedule_for_platform('cloud')
             for cloud_provider in version['providers']:
                 platform_name = cloud_provider['name']
                 for profile in cloud_provider['profiles']:
@@ -28,7 +29,8 @@ class Manifest():
                         "releaseStream": release_stream,
                         "platform": platform_name,
                         "versionAlias": version_alias,
-                        "profile": profile
+                        "profile": profile,
+                        "scheduleInterval": schedule
                     })
 
     def get_baremetal_releases(self):
@@ -36,6 +38,7 @@ class Manifest():
             version_number = version['version']
             release_stream = version['releaseStream']
             build = version['build']
+            schedule = self._get_schedule_for_platform('baremetal')
             version_alias = self.get_version_alias(version_number)
             for profile in version['profiles']:
                 self.releases.append({
@@ -44,7 +47,8 @@ class Manifest():
                     "platform": "baremetal",
                     "build": build,
                     "versionAlias": version_alias,
-                    "profile": profile
+                    "profile": profile,
+                    "scheduleInterval": schedule
                 })
             
     def get_openstack_releases(self):
@@ -52,13 +56,15 @@ class Manifest():
             version_number = version['version']
             release_stream = version['releaseStream']
             version_alias = self.get_version_alias(version_number)
+            schedule = self._get_schedule_for_platform('openstack')
             for profile in version['profiles']:
                 self.releases.append({
                     "version": version_number,
                     "releaseStream": release_stream,
                     "platform": "openstack",
                     "versionAlias": version_alias,
-                    "profile": profile
+                    "profile": profile,
+                    "scheduleInterval": schedule
                 })
 
 
@@ -67,3 +73,11 @@ class Manifest():
         self.get_baremetal_releases()
         self.get_openstack_releases()
         return self.releases
+
+    
+    def _get_schedule_for_platform(self, platform):
+        schedules = self.yaml['schedules']
+        if bool(schedules.get("enabled", False)):
+            return schedules.get(platform, schedules['default'])
+        else:
+            return None

--- a/dags/openshift_nightlies/util/manifest.py
+++ b/dags/openshift_nightlies/util/manifest.py
@@ -1,4 +1,5 @@
 import yaml
+import sys
 sys.path.insert(0, dirname(abspath(dirname(__file__))))
 from models.dag_config import DagConfig
 from models.release import OpenshiftRelease, BaremetalRelease

--- a/dags/openshift_nightlies/util/manifest.py
+++ b/dags/openshift_nightlies/util/manifest.py
@@ -1,5 +1,6 @@
 import yaml
 import sys
+from os.path import abspath, dirname
 sys.path.insert(0, dirname(abspath(dirname(__file__))))
 from models.dag_config import DagConfig
 from models.release import OpenshiftRelease, BaremetalRelease

--- a/dags/openshift_nightlies/util/manifest.py
+++ b/dags/openshift_nightlies/util/manifest.py
@@ -105,8 +105,7 @@ class Manifest():
         else:
             return None
     
-    def _build_dag_config(schedule_interval):
-
+    def _build_dag_config(self, schedule_interval):
         return DagConfig(
             schedule_interval=schedule_interval,
             cleanup_on_success=bool(self.yaml['dagConfig']['cleanupOnSuccess'])

--- a/dags/openshift_nightlies/util/manifest.py
+++ b/dags/openshift_nightlies/util/manifest.py
@@ -1,22 +1,23 @@
 import yaml
-
+sys.path.insert(0, dirname(abspath(dirname(__file__))))
+from models.dag_config import DagConfig
+from models.release import OpenshiftRelease, BaremetalRelease
 
 class Manifest():
-    def __init__(self, root_dag_dir): 
+    def __init__(self, root_dag_dir):
         with open(f"{root_dag_dir}/manifest.yaml") as manifest_file:
             try:
-                self.yaml =  yaml.safe_load(manifest_file)
+                self.yaml = yaml.safe_load(manifest_file)
             except yaml.YAMLError as exc:
                 print(exc)
         self.releases = []
-
 
     def get_version_alias(self, version):
         aliases = self.yaml['versionAliases']
         return [alias['alias'] for alias in aliases if alias['version'] == version][0]
 
     def get_cloud_releases(self):
-        for version in self.yaml['platforms'].get('cloud', []): 
+        for version in self.yaml['platforms'].get('cloud', []):
             version_number = version['version']
             release_stream = version['releaseStream']
             version_alias = self.get_version_alias(version_number)
@@ -24,49 +25,75 @@ class Manifest():
             for cloud_provider in version['providers']:
                 platform_name = cloud_provider['name']
                 for profile in cloud_provider['profiles']:
-                    self.releases.append({
-                        "version": version_number,
-                        "releaseStream": release_stream,
-                        "platform": platform_name,
-                        "versionAlias": version_alias,
-                        "profile": profile,
-                        "scheduleInterval": schedule
-                    })
+                    release = OpenshiftRelease(
+                        platform=platform_name,
+                        version=version_number,
+                        release_stream=release_stream,
+                        profile=profile,
+                        version_alias=version_alias
+                    )
+                    dag_config = DagConfig(
+                        schedule_interval=schedule
+                    )
+
+                    self.releases.append(
+                        {
+                            "config": dag_config,
+                            "release": release
+                        }
+                    )
 
     def get_baremetal_releases(self):
-        for version in self.yaml['platforms'].get('baremetal', []): 
+        for version in self.yaml['platforms'].get('baremetal', []):
             version_number = version['version']
             release_stream = version['releaseStream']
             build = version['build']
             schedule = self._get_schedule_for_platform('baremetal')
             version_alias = self.get_version_alias(version_number)
             for profile in version['profiles']:
-                self.releases.append({
-                    "version": version_number,
-                    "releaseStream": release_stream,
-                    "platform": "baremetal",
-                    "build": build,
-                    "versionAlias": version_alias,
-                    "profile": profile,
-                    "scheduleInterval": schedule
-                })
-            
+                release = BaremetalRelease(
+                    platform="baremetal",
+                    version=version_number,
+                    release_stream=release_stream,
+                    profile=profile,
+                    version_alias=version_alias,
+                    build=build
+                )
+                dag_config = DagConfig(
+                    schedule_interval=schedule
+                )
+
+                self.releases.append(
+                    {
+                        "config": dag_config,
+                        "release": release
+                    }
+                )
+
     def get_openstack_releases(self):
-        for version in self.yaml['platforms'].get('openstack', []): 
+        for version in self.yaml['platforms'].get('openstack', []):
             version_number = version['version']
             release_stream = version['releaseStream']
             version_alias = self.get_version_alias(version_number)
             schedule = self._get_schedule_for_platform('openstack')
             for profile in version['profiles']:
-                self.releases.append({
-                    "version": version_number,
-                    "releaseStream": release_stream,
-                    "platform": "openstack",
-                    "versionAlias": version_alias,
-                    "profile": profile,
-                    "scheduleInterval": schedule
-                })
+                release = OpenshiftRelease(
+                    platform="openstack",
+                    version=version_number,
+                    release_stream=release_stream,
+                    profile=profile,
+                    version_alias=version_alias
+                )
+                dag_config = DagConfig(
+                    schedule_interval=schedule
+                )
 
+                self.releases.append(
+                    {
+                        "config": dag_config,
+                        "release": release
+                    }
+                )
 
     def get_releases(self):
         self.get_cloud_releases()
@@ -74,7 +101,6 @@ class Manifest():
         self.get_openstack_releases()
         return self.releases
 
-    
     def _get_schedule_for_platform(self, platform):
         schedules = self.yaml['schedules']
         if bool(schedules.get("enabled", False)):

--- a/dags/openshift_nightlies/util/var_loader.py
+++ b/dags/openshift_nightlies/util/var_loader.py
@@ -17,16 +17,6 @@ def get_git_user():
     git_user = git_path.split('/')[0]
     return git_user.lower()
 
-def get_latest_release_from_stream(base_url, release_stream):
-    url = f"{base_url}/{release_stream}/latest"
-    payload = requests.get(url).json()
-    latest_accepted_release = payload["name"]
-    latest_accepted_release_url = payload["downloadURL"]
-    return {
-        "openshift_client_location": f"{latest_accepted_release_url}/openshift-client-linux-{latest_accepted_release}.tar.gz",
-        "openshift_install_binary_url": f"{latest_accepted_release_url}/openshift-install-linux-{latest_accepted_release}.tar.gz"
-    }
-
 def get_elastic_url():
     elasticsearch_config = Variable.get("elasticsearch_config", deserialize_json=True)
     if 'username' in elasticsearch_config and 'password' in elasticsearch_config:

--- a/scripts/playground/templates/airflow.yaml
+++ b/scripts/playground/templates/airflow.yaml
@@ -73,6 +73,8 @@ spec:
         value: $_remote_origin_url
       - name: dags.gitSync.branch
         value: $_raw_branch
+      - name: config.elasticsearch.frontend
+        value: logging-kibana.$_cluster_domain/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30m,to:now))&_a=(columns:!(message),filters:!(),index:a16f10f0-cf86-11eb-a0b9-a32be872b9a2,interval:auto,query:(language:kuery,query:'log_id:{log_id}'),sort:!())   
   syncPolicy:
     automated:
       prune: true

--- a/scripts/playground/templates/airflow.yaml
+++ b/scripts/playground/templates/airflow.yaml
@@ -74,7 +74,7 @@ spec:
       - name: dags.gitSync.branch
         value: $_raw_branch
       - name: config.elasticsearch.frontend
-        value: logging-kibana.$_cluster_domain/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30m,to:now))&_a=(columns:!(message),filters:!(),index:a16f10f0-cf86-11eb-a0b9-a32be872b9a2,interval:auto,query:(language:kuery,query:'log_id:{log_id}'),sort:!())   
+        value: "logging-kibana.$_cluster_domain/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30m,to:now))&_a=(columns:!(message),filters:!(),index:a16f10f0-cf86-11eb-a0b9-a32be872b9a2,interval:auto,query:(language:kuery,query:'log_id:{log_id}'),sort:!())"   
   syncPolicy:
     automated:
       prune: true

--- a/scripts/playground/templates/airflow.yaml
+++ b/scripts/playground/templates/airflow.yaml
@@ -26,6 +26,7 @@ spec:
             remote_logging: "True"
           elasticsearch:
             write_stdout: "True"
+            frontend: logging-kibana.$_cluster_domain/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30m,to:now))&_a=(columns:!(message),filters:!(),index:a16f10f0-cf86-11eb-a0b9-a32be872b9a2,interval:auto,query:(language:kuery,query:'log_id:"{log_id}"'),sort:!())
           elasticsearch_configs:
             use_ssl: "False"
             verify_certs: "False"
@@ -73,8 +74,6 @@ spec:
         value: $_remote_origin_url
       - name: dags.gitSync.branch
         value: $_raw_branch
-      - name: config.elasticsearch.frontend
-        value: "logging-kibana.$_cluster_domain/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30m,to:now))&_a=(columns:!(message),filters:!(),index:a16f10f0-cf86-11eb-a0b9-a32be872b9a2,interval:auto,query:(language:kuery,query:'log_id:{log_id}'),sort:!())"   
   syncPolicy:
     automated:
       prune: true

--- a/scripts/values/update.yaml
+++ b/scripts/values/update.yaml
@@ -12,6 +12,8 @@ airflow:
         instance_name: Performance and Scale
         expose_config: True
         default_ui_timezone: America/New_York
+      elasticsearch:
+        frontend: logging-kibana.$_cluster_domain/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30m,to:now))&_a=(columns:!(message),filters:!(),index:a16f10f0-cf86-11eb-a0b9-a32be872b9a2,interval:auto,query:(language:kuery,query:'log_id:"{log_id}"'),sort:!())
     defaultAirflowTag: 2.1.1rc1-python3.8
     webserver:
       defaultUser:


### PR DESCRIPTION
### Description

Some QOL Updates to make development easier as our dags are getting more complex.

### Highlights

* Parameterizes the dag `schedule_interval` within the manifest at the platform level while allowing for a default. 
* `schedules.enabled` added to the manifest which lets users turn off scheduling and only allow manual triggering of DAGs.
* Creates models for  `OpenshiftRelease`, `BaremetalRelease`, and  `DagConfig` to make handling the release/dag configurations easier throughout the codebase. 
* Made the Baremetal installer inherit from the `AbstractOpenshiftInstaller` 

4.8 test run http://whitleykeith-qol-updates-airflow.apps.sailplane.perf.lab.eng.rdu2.redhat.com/tree?dag_id=4.8_aws_default

