### PR TITLE
Adding ability to accept aws region

### DIFF
--- a/dags/openshift_nightlies/scripts/install/cloud.sh
+++ b/dags/openshift_nightlies/scripts/install/cloud.sh
@@ -20,7 +20,7 @@ setup(){
     git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
     export PUBLIC_KEY=/home/airflow/workspace/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
     export PRIVATE_KEY=/home/airflow/workspace/perf-dept/ssh_keys/id_rsa_pbench_ec2 
-    export AWS_REGION=us-west-2
+    export AWS_REGION=${AWS_REGION:-us-west-2}
     chmod 600 ${PRIVATE_KEY}
 
 

--- a/dags/openshift_nightlies/tasks/install/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/openshift.py
@@ -87,7 +87,7 @@ class AbstractOpenshiftInstaller(ABC):
             "KUBECONFIG_NAME": f"{self.release_name}-kubeconfig",
             "KUBEADMIN_NAME": f"{self.release_name}-kubeadmin",
             "OPENSHIFT_INSTALL_PULL_SECRET": self.ocp_pull_secret,
-            "AWS_REGION": self.config['aws_region'],
+            "AWS_REGION": self.config['aws_region_for_openshift'],
             **self._insert_kube_env()
         }
 

--- a/dags/openshift_nightlies/tasks/install/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/openshift.py
@@ -87,6 +87,7 @@ class AbstractOpenshiftInstaller(ABC):
             "KUBECONFIG_NAME": f"{self.release_name}-kubeconfig",
             "KUBEADMIN_NAME": f"{self.release_name}-kubeadmin",
             "OPENSHIFT_INSTALL_PULL_SECRET": self.ocp_pull_secret,
+            "AWS_REGION": self.config['aws_region'],
             **self._insert_kube_env()
         }
 


### PR DESCRIPTION
Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>

### Description
Be able to specify the region part of the aws creds in the airflow vars.

### Usage
```{ "aws_access_key_id": "key", "aws_profile": "default", "aws_secret_access_key": "another_key", "aws_region_for_openshift": "us-east-2" }```

Without the region, install might fail. This is to force users to be conscious about where they are installing the cluster, and not hit quota or billing issues. Changing from `aws_region` to `aws_region_for_openshift` -> as if we use `aws_region` it fails in the post install here: https://github.com/cloud-bulldozer/scale-ci-deploy/blob/89116d091c9007d1b579c847ffd36f0398228431/OCP-4.X/roles/post-install/templates/aws-infra-node-machineset.yml.j2