### PR TITLE
fixing playground user templates to support restricted kubeconfig

### DIFF
--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -47,7 +47,7 @@ images:
   airflow:
     repository: ~
     tag: ~
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   pod_template:
     repository: ~
     tag: ~

--- a/scripts/playground/build.sh
+++ b/scripts/playground/build.sh
@@ -24,5 +24,5 @@ if [[ -z "$password" ]]; then
 fi
 
 
-kubectl create namespace $_airflow_namespace || true
+oc new-project $_airflow_namespace || true
 envsubst < $GIT_ROOT/scripts/playground/templates/airflow.yaml | kubectl apply -f -

--- a/scripts/playground/cleanup.sh
+++ b/scripts/playground/cleanup.sh
@@ -13,4 +13,4 @@ _cluster_domain=$(kubectl get ingresses.config.openshift.io/cluster -o jsonpath=
 
 
 envsubst < $GIT_ROOT/scripts/playground/templates/airflow.yaml | kubectl delete -f -
-kubectl delete namespace $_airflow_namespace || true
+oc delete project/$_airflow_namespace || true

--- a/scripts/playground/templates/airflow.yaml
+++ b/scripts/playground/templates/airflow.yaml
@@ -97,9 +97,10 @@ spec:
   wildcardPolicy: None
 --- 
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: $_remote_user-$_branch-pod-reader
+  namespace: $_airflow_namespace
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["pods", "pods/log"]
@@ -107,9 +108,10 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 # This cluster role binding allows anyone in the "manager" group to read secrets in any namespace.
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: $_remote_user-$_branch-pod-reader
+  namespace: $_airflow_namespace
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 subjects:
@@ -120,7 +122,7 @@ subjects:
   name: airflow-worker # Name is case sensitive
   namespace: $_airflow_namespace
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: $_remote_user-$_branch-pod-reader
   apiGroup: rbac.authorization.k8s.io
 ---


### PR DESCRIPTION
this along with a restricted kubeconfig will allow people to create necessary objects in our cluster without giving them full admin access. 