### PR TITLE
disabled openshift install using shift-on-stack repo

### DIFF
--- a/dags/openshift_nightlies/tasks/install/openstack/jetpack.py
+++ b/dags/openshift_nightlies/tasks/install/openstack/jetpack.py
@@ -47,3 +47,11 @@ class OpenstackJetpackInstaller(AbstractOpenshiftInstaller):
         with open(f"/tmp/{self.release_name}-{operation}-task.json", 'w') as json_file:
             json.dump(self.config, json_file, sort_keys=True, indent=4)   
 
+
+    def _get_playbook_operations(self, operation):
+        if operation == "install":
+            return {"openshift_cleanup": False, "openshift_debug_config": False,
+                                   "openshift_install": False, "openshift_post_config": True, "openshift_post_install": False}
+        else:
+            return {"openshift_cleanup": True, "openshift_debug_config": False,
+                                   "openshift_install": False, "openshift_post_config": False, "openshift_post_install": False}


### PR DESCRIPTION
### Description
shift on stack CI uses Jetpack for openshift cluster installation. Disabled the default scale-ci-deploy install script.
