### PR TITLE
add exported /home/morenod to rosa scripts, it is required by new rosa cli 1.1.1

### DIFF
--- a/dags/openshift_nightlies/scripts/install/osde2e.sh
+++ b/dags/openshift_nightlies/scripts/install/osde2e.sh
@@ -28,6 +28,7 @@ setup(){
     mkdir /home/airflow/workspace
     cd /home/airflow/workspace
     export PATH=$PATH:/usr/bin
+    export HOME=/home/airflow
     export AWS_REGION=us-west-2
     export AWS_ACCESS_KEY_ID=$(cat ${json_file} | jq -r .aws_access_key_id)
     export AWS_SECRET_ACCESS_KEY=$(cat ${json_file} | jq -r .aws_secret_access_key)

--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -28,6 +28,7 @@ setup(){
     mkdir /home/airflow/workspace
     cd /home/airflow/workspace
     export PATH=$PATH:/usr/bin
+    export HOME=/home/airflow
     export AWS_REGION=us-west-2
     export AWS_ACCESS_KEY_ID=$(cat ${json_file} | jq -r .aws_access_key_id)
     export AWS_SECRET_ACCESS_KEY=$(cat ${json_file} | jq -r .aws_secret_access_key)


### PR DESCRIPTION
### Description

New version of rosa cli fails to execute commands if $HOME var is not set:

$ unset HOME
$ rosa version
1.1.0
$ rosa login --env=staging
I: Logged in as 'dsanzmor@redhat.com' on 'https://api.stage.openshift.com'
$ /tmp/rosa version
1.1.1
$ /tmp/rosa login --env=staging
E: Failed to load config file: $HOME is not defined
$ export HOME=/home/morenod
$ /tmp/rosa login --env=staging
I: Logged in as 'dsanzmor@redhat.com' on 'https://api.stage.openshift.com'
