### PR TITLE
Add Must-gather after every task on airflow

### DIFF
--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -76,6 +76,18 @@ else
     export UUID=$(uuidgen)
     eval "$command"
     benchmark_rv=$?
+
+    if [[ ${MUST_GATHER_EACH_TASK} == "true" ]] ; then
+        echo -e "must gather collection enabled for this task"
+        cd ../../utils/scale-ci-diagnosis
+        export OUTPUT_DIR=$PWD
+        export PROMETHEUS_CAPTURE=false
+        export PROMETHEUS_CAPTURE_TYPE=full
+        export OPENSHIFT_MUST_GATHER=true
+        export STORAGE_MODE=snappy
+        export WORKLOAD=$AIRFLOW_CTX_TASK_ID-must-gather
+        ./ocp_diagnosis.sh
+    fi
     echo $UUID
     exit $benchmark_rv
 

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -86,7 +86,7 @@ else
         export OPENSHIFT_MUST_GATHER=true
         export STORAGE_MODE=snappy
         export WORKLOAD=$AIRFLOW_CTX_TASK_ID-must-gather
-        ./ocp_diagnosis.sh
+        ./ocp_diagnosis.sh || true
     fi
     echo $UUID
     exit $benchmark_rv

--- a/dags/openshift_nightlies/tasks/benchmarks/defaults.json
+++ b/dags/openshift_nightlies/tasks/benchmarks/defaults.json
@@ -29,7 +29,8 @@
                 "LOG_LEVEL": "info",
                 "LOG_STREAMING": "true",
                 "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true"
+                "CLEANUP": "true",
+                "MUST_GATHER_EACH_TASK": "true"
             }
         },
         {
@@ -47,7 +48,8 @@
                 "LOG_LEVEL": "info",
                 "LOG_STREAMING": "true",
                 "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true"
+                "CLEANUP": "true",
+                "MUST_GATHER_EACH_TASK": "true"
             }
         },
         {
@@ -74,7 +76,8 @@
                 "LOG_LEVEL": "info",
                 "LOG_STREAMING": "true",
                 "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true"
+                "CLEANUP": "true",
+                "MUST_GATHER_EACH_TASK": "true"
             }
         },
         {


### PR DESCRIPTION
### Description
This PR adds an option to enable must-gather after any/every task on airflow.We have to set the env var MUST_GATHER_EACH_TASK in the env section of a task on the defaults.json or benchmarks.json file to enable or disable the must-gather step after that task.
The collected must-gather tar files will be sent to snappy. 

