### PR TITLE
add ocp_network_type var from vault

### DIFF
--- a/dags/openshift_nightlies/tasks/install/openstack/jetpack.py
+++ b/dags/openshift_nightlies/tasks/install/openstack/jetpack.py
@@ -43,6 +43,11 @@ class OpenstackJetpackInstaller(AbstractOpenshiftInstaller):
             **self._insert_kube_env()
         }
 
+        # Here if network type is defined in the vars, it will be set else, network type
+        # is decided based on the day of the week.
+        if self.config['ocp_network_type'] != "":
+            self.env["OPENSHIFT_NETWORK_TYPE"] = self.config['ocp_network_type']
+
         # Dump all vars to json file for Ansible to pick up
         with open(f"/tmp/{self.release_name}-{operation}-task.json", 'w') as json_file:
             json.dump(self.config, json_file, sort_keys=True, indent=4)   


### PR DESCRIPTION
### Description
Get network type var from vault to override in case we need to run test on a particular network type in shift-on-stack CI
