### PR TITLE
Disable the ACS install task for cleanup

### DIFF
--- a/dags/openshift_nightlies/tasks/install/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/openshift.py
@@ -107,7 +107,8 @@ class AbstractOpenshiftInstaller(ABC):
                     "openshift_install": True, "openshift_post_config": True, "openshift_post_install": True}
         else:
             return {"openshift_cleanup": True, "openshift_debug_config": False,
-                    "openshift_install": False, "openshift_post_config": False, "openshift_post_install": False}
+                    "openshift_install": False, "openshift_post_config": False, "openshift_post_install": False,
+                    "rhacs_enable": False}
 
     # This Helper Injects Airflow environment variables into the task execution runtime
     # This allows the task to interface with the Kubernetes cluster Airflow is hosted on.


### PR DESCRIPTION
Ensures that when `rhacs_enable` is set it is overridden for the cleanup task. i.e. so that there is no attempt to install ACS during cleanup.