### PR TITLE
disable resource cleanup from cluster-density before running upgrade test

### DIFF
--- a/dags/openshift_nightlies/tasks/benchmarks/defaults.json
+++ b/dags/openshift_nightlies/tasks/benchmarks/defaults.json
@@ -154,7 +154,7 @@
                 "METRICS_PROFILE": "metrics-aggregated.yaml",
                 "LOG_LEVEL": "info",
                 "LOG_STREAMING": "true",
-                "CLEANUP_WHEN_FINISH": "true",
+                "CLEANUP_WHEN_FINISH": "false",
                 "CLEANUP": "true"
             }
         },


### PR DESCRIPTION
### Description
Set CLEANUP_WHEN_FINISH to false when running cluster-density before running upgrade test.