### PR TITLE
add node-density heavy to the perfscale CI

### DIFF
--- a/dags/openshift_nightlies/releases/4.7/openstack/default/benchmarks.json
+++ b/dags/openshift_nightlies/releases/4.7/openstack/default/benchmarks.json
@@ -51,6 +51,24 @@
             }
         },
         {
+            "name": "node_density_heavy",
+            "workload": "kube-burner",
+            "command": "./run_nodedensity-heavy_test_fromgit.sh",
+            "env": {
+                "PODS_PER_NODE": "250",
+                "NODE_COUNT": "25",
+                "JOB_TIMEOUT": "18000",
+                "QPS": "20",
+                "BURST": "20",
+                "STEP_SIZE": "30s",
+                "METRICS_PROFILE": "metrics.yaml",
+                "LOG_LEVEL": "info",
+                "LOG_STREAMING": "true",
+                "CLEANUP_WHEN_FINISH": "true",
+                "CLEANUP": "true"
+            }
+        },
+        {
             "name": "scale_50",
             "workload": "scale-perf",
             "command": "./run_scale_fromgit.sh",

--- a/dags/openshift_nightlies/releases/4.8/openstack/default/benchmarks.json
+++ b/dags/openshift_nightlies/releases/4.8/openstack/default/benchmarks.json
@@ -51,6 +51,24 @@
             }
         },
         {
+            "name": "node_density_heavy",
+            "workload": "kube-burner",
+            "command": "./run_nodedensity-heavy_test_fromgit.sh",
+            "env": {
+                "PODS_PER_NODE": "250",
+                "NODE_COUNT": "25",
+                "JOB_TIMEOUT": "18000",
+                "QPS": "20",
+                "BURST": "20",
+                "STEP_SIZE": "30s",
+                "METRICS_PROFILE": "metrics.yaml",
+                "LOG_LEVEL": "info",
+                "LOG_STREAMING": "true",
+                "CLEANUP_WHEN_FINISH": "true",
+                "CLEANUP": "true"
+            }
+        },
+        {
             "name": "scale_50",
             "workload": "scale-perf",
             "command": "./run_scale_fromgit.sh",

--- a/dags/openshift_nightlies/releases/4.9/openstack/default/benchmarks.json
+++ b/dags/openshift_nightlies/releases/4.9/openstack/default/benchmarks.json
@@ -51,6 +51,24 @@
             }
         },
         {
+            "name": "node_density_heavy",
+            "workload": "kube-burner",
+            "command": "./run_nodedensity-heavy_test_fromgit.sh",
+            "env": {
+                "PODS_PER_NODE": "250",
+                "NODE_COUNT": "25",
+                "JOB_TIMEOUT": "18000",
+                "QPS": "20",
+                "BURST": "20",
+                "STEP_SIZE": "30s",
+                "METRICS_PROFILE": "metrics.yaml",
+                "LOG_LEVEL": "info",
+                "LOG_STREAMING": "true",
+                "CLEANUP_WHEN_FINISH": "true",
+                "CLEANUP": "true"
+            }
+        },
+        {
             "name": "scale_50",
             "workload": "scale-perf",
             "command": "./run_scale_fromgit.sh",

--- a/dags/openshift_nightlies/tasks/benchmarks/defaults.json
+++ b/dags/openshift_nightlies/tasks/benchmarks/defaults.json
@@ -51,6 +51,24 @@
             }
         },
         {
+            "name": "node_density_heavy",
+            "workload": "kube-burner",
+            "command": "./run_nodedensity-heavy_test_fromgit.sh",
+            "env": {
+                "PODS_PER_NODE": "250",
+                "NODE_COUNT": "25",
+                "JOB_TIMEOUT": "18000",
+                "QPS": "20",
+                "BURST": "20",
+                "STEP_SIZE": "30s",
+                "METRICS_PROFILE": "metrics.yaml",
+                "LOG_LEVEL": "info",
+                "LOG_STREAMING": "true",
+                "CLEANUP_WHEN_FINISH": "true",
+                "CLEANUP": "true"
+            }
+        },
+        {
             "name": "scale_50",
             "workload": "scale-perf",
             "command": "./run_scale_fromgit.sh",


### PR DESCRIPTION
### Description
Added node-density heavy at 25 scale and 250 pods per node config, we mention results for this config in our reports and can be helpful to track in our CI.
