### PR TITLE
Manual UUID

### DIFF
--- a/dags/openshift_nightlies/scripts/index.sh
+++ b/dags/openshift_nightlies/scripts/index.sh
@@ -12,7 +12,7 @@ export airflow_base_url="http://$(kubectl get route/airflow -n airflow -o jsonpa
 
 setup(){
     # Generate a uuid
-    export UUID=$(uuidgen)
+    export UUID=${UUID:-$(uuidgen)}
 
     # Elasticsearch Config
     export ES_SERVER=$ES_SERVER

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -77,6 +77,6 @@ else
     eval "$command"
     benchmark_rv=$?
     echo $UUID
-    exit benchmark_rv
+    exit $benchmark_rv
 
 fi

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -14,7 +14,7 @@ done
 setup(){
     mkdir /home/airflow/workspace
     cd /home/airflow/workspace
-    git clone https://github.com/cloud-bulldozer/e2e-benchmarking
+    git clone -b manual-uuid https://github.com/whitleykeith/e2e-benchmarking
     cp /home/airflow/auth/config /home/airflow/workspace/config
     export KUBECONFIG=/home/airflow/workspace/config
     curl http://dell-r510-01.perf.lab.eng.rdu2.redhat.com/msheth/gsheet_key.json > /tmp/key.json

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -11,7 +11,7 @@ done
 setup(){
     mkdir /home/airflow/workspace
     cd /home/airflow/workspace
-    git clone -b manual-uuid https://github.com/whitleykeith/e2e-benchmarking
+    git clone -b master https://github.com/cloud-bulldozer/e2e-benchmarking
     cp /home/airflow/auth/config /home/airflow/workspace/config
     export KUBECONFIG=/home/airflow/workspace/config
     curl http://dell-r510-01.perf.lab.eng.rdu2.redhat.com/msheth/gsheet_key.json > /tmp/key.json

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-set -eux
-
 while getopts w:c: flag
 do
     case "${flag}" in
@@ -68,13 +65,18 @@ EOF
 }
 
 if [[ $PLATFORM == "baremetal" ]]; then
-env >> /tmp/environment.txt
-run_baremetal_benchmark
-echo "Finished e2e scripts for $workload"
+    env >> /tmp/environment.txt
+    run_baremetal_benchmark
+    echo "Finished e2e scripts for $workload"
 else
-setup
-cd /home/airflow/workspace
-ls
-cd e2e-benchmarking/workloads/$workload
-eval "$command"
+    setup
+    cd /home/airflow/workspace
+    ls
+    cd e2e-benchmarking/workloads/$workload
+    export UUID=$(uuidgen)
+    eval "$command"
+    benchmark_rv=$?
+    echo $UUID
+    exit benchmark_rv
+
 fi

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -85,8 +85,8 @@ class E2EBenchmarks():
                 benchmarks[index] = self._get_benchmarks(benchmark['benchmarks'])
         return benchmarks
 
-    def _add_indexer(self, benchmark, uuid): 
-        indexer = StatusIndexer(self.dag, self.dag_config, self.release, benchmark.task_id, uuid).get_index_task() 
+    def _add_indexer(self, benchmark, benchmark_uuid): 
+        indexer = StatusIndexer(self.dag, self.dag_config, self.release, benchmark.task_id, benchmark_uuid).get_index_task() 
         benchmark >> indexer 
 
     def _get_benchmark(self, benchmark):

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -6,7 +6,6 @@ from openshift_nightlies.models.release import OpenshiftRelease
 from openshift_nightlies.models.dag_config import DagConfig
 
 import json
-import uuid
 from datetime import timedelta
 from airflow.operators.bash import BashOperator
 from airflow.models import Variable

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -103,5 +103,5 @@ class E2EBenchmarks():
                 executor_config=self.exec_config
         )
 
-        self._add_indexer(task, uuid)
+        self._add_indexer(task, benchmark_uuid)
         return task

--- a/dags/openshift_nightlies/tasks/index/status.py
+++ b/dags/openshift_nightlies/tasks/index/status.py
@@ -31,7 +31,7 @@ class StatusIndexer():
             "RELEASE_STREAM": self.release.release_stream,
             "TASK": self.task
         }
-        
+
         self.git_user = var_loader.get_git_user()
         if self.git_user == 'cloud-bulldozer':
             self.env["ES_INDEX"] = "perf_scale_ci"
@@ -50,7 +50,7 @@ class StatusIndexer():
         return BashOperator(
             task_id=f"index_{self.task}",
             depends_on_past=False,
-            bash_command=f' UUID={{ ti.xcom_pull({self.task}) }}{constants.root_dag_dir}/scripts/index.sh ',
+            bash_command=f'UUID={{{{ ti.xcom_pull({self.task}) }}}} {constants.root_dag_dir}/scripts/index.sh ',
             retries=3,
             dag=self.dag,
             trigger_rule="all_done",

--- a/dags/openshift_nightlies/tasks/index/status.py
+++ b/dags/openshift_nightlies/tasks/index/status.py
@@ -14,7 +14,7 @@ from kubernetes.client import models as k8s
 
 # Defines Task for Indexing Task Status in ElasticSearch
 class StatusIndexer():
-    def __init__(self, dag, config: DagConfig, release: OpenshiftRelease, task):
+    def __init__(self, dag, config: DagConfig, release: OpenshiftRelease, task, uuid=None):
         
         # General DAG Configuration
         self.dag = dag
@@ -31,6 +31,9 @@ class StatusIndexer():
             "RELEASE_STREAM": self.release.release_stream,
             "TASK": self.task
         }
+
+        if uuid is not None:
+            self.env["UUID"] = uuid
         self.git_user = var_loader.get_git_user()
         if self.git_user == 'cloud-bulldozer':
             self.env["ES_INDEX"] = "perf_scale_ci"

--- a/dags/openshift_nightlies/tasks/index/status.py
+++ b/dags/openshift_nightlies/tasks/index/status.py
@@ -46,11 +46,15 @@ class StatusIndexer():
             **{"ES_SERVER": var_loader.get_secret('elasticsearch')},
             **environ
         }
+        if self.task != "install":
+            command = f'UUID={{{{ ti.xcom_pull("{self.task}") }}}} {constants.root_dag_dir}/scripts/index.sh '
+        else:
+            command = f'{constants.root_dag_dir}/scripts/index.sh '
     
         return BashOperator(
             task_id=f"index_{self.task}",
             depends_on_past=False,
-            bash_command=f'UUID={{{{ ti.xcom_pull("{self.task}") }}}} {constants.root_dag_dir}/scripts/index.sh ',
+            bash_command=command,
             retries=3,
             dag=self.dag,
             trigger_rule="all_done",

--- a/dags/openshift_nightlies/tasks/index/status.py
+++ b/dags/openshift_nightlies/tasks/index/status.py
@@ -50,7 +50,7 @@ class StatusIndexer():
         return BashOperator(
             task_id=f"index_{self.task}",
             depends_on_past=False,
-            bash_command=f'UUID={{{{ ti.xcom_pull({self.task}) }}}} {constants.root_dag_dir}/scripts/index.sh ',
+            bash_command=f'UUID={{{{ ti.xcom_pull("{self.task}") }}}} {constants.root_dag_dir}/scripts/index.sh ',
             retries=3,
             dag=self.dag,
             trigger_rule="all_done",


### PR DESCRIPTION
Generates benchmark UUID outside of e2e scripts in order to pass them to indexers to make it easier to find benchmark uuids

Depends on https://github.com/cloud-bulldozer/e2e-benchmarking/pull/256