### PR TITLE
baremetal scale up with step size

### DIFF
--- a/dags/openshift_nightlies/tasks/install/baremetal/jetski.py
+++ b/dags/openshift_nightlies/tasks/install/baremetal/jetski.py
@@ -54,7 +54,9 @@ class BaremetalOpenshiftInstaller(AbstractOpenshiftInstaller):
             "JETSKI_SKIPTAGS": config['jetski_skiptags'],
             "KUBECONFIG_PATH": config['kubeconfig_path'],
             "KUBECONFIG_NAME": f"{self.release_name}-kubeconfig",
-            "KUBEADMIN_NAME": f"{self.release_name}-kubeadmin",            
+            "KUBEADMIN_NAME": f"{self.release_name}-kubeadmin",
+            "CURRENT_WORKER_COUNT": config['openshift_worker_count'],
+            "TARGET_WORKER_COUNT": config['openshift_worker_scaleup_target'],
             **self._insert_kube_env()
         }
 


### PR DESCRIPTION
### Description
Modified baremetal script to scale workers within the [limit](https://docs.openshift.com/container-platform/4.8/scalability_and_performance/recommended-cluster-scaling-practices.html#recommended-scale-practices_cluster-scaling), so script adds 40 workers at a time instead of adding all 250 nodes at once. 
This limit is supposed to be extended in future(4.10), will revisit later. 
### Fixes
