### PR TITLE
Add bc to airflow-ansible image because of #68

### DIFF
--- a/images/airflow-ansible/Dockerfile
+++ b/images/airflow-ansible/Dockerfile
@@ -1,3 +1,6 @@
 ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.1.3
 FROM ${BASE_IMAGE}
+USER root
+RUN apt install bc
+USER airflow
 RUN yes | pip install ansible netaddr


### PR DESCRIPTION
### Description
bc is required by uperf script to find the golder UUID
### Fixes
#68 