### PR TITLE
update cloud-bulldozer/airflow image references to 2.2.0 after being created on 2aae0316562f3a1d6eb203088a2cac6e90bb1736

### DIFF
--- a/charts/perfscale/values.yaml
+++ b/charts/perfscale/values.yaml
@@ -15,8 +15,8 @@ airflow:
   values: 
     executor: KubernetesExecutor
     defaultAirflowRepository: quay.io/cloud-bulldozer/airflow
-    defaultAirflowTag: 2.1.3
-    airflowVersion: 2.1.3
+    defaultAirflowTag: 2.2.0
+    airflowVersion: 2.2.0
     config:
       logging:
         colored_console_log: "False"

--- a/dags/openshift_nightlies/models/dag_config.py
+++ b/dags/openshift_nightlies/models/dag_config.py
@@ -18,6 +18,6 @@ class DagConfig:
         })
     executor_image: Optional[dict] = field(default_factory=lambda: {
             "repository": "quay.io/cloud-bulldozer",
-            "tag": "2.1.3"
+            "tag": "2.2.0"
         })
     dependencies: Optional[dict] = field(default_factory=lambda: {})

--- a/images/airflow-ansible/Dockerfile
+++ b/images/airflow-ansible/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.1.3
+ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.2.0
 FROM ${BASE_IMAGE}
 USER root
 RUN apt install bc

--- a/images/airflow-managed-services/Dockerfile
+++ b/images/airflow-managed-services/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.1.3
+ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.2.0
 FROM golang:latest AS build
 
 RUN git clone https://github.com/openshift/osde2e.git /osde2e


### PR DESCRIPTION
Commit 2aae0316562f3a1d6eb203088a2cac6e90bb1736 created the 2.2.0 tag on cloud-bulldozer/airflow image, but code still uses the 2.1.3

Also updating managed services images to use the new tag for base image
