### PR TITLE
rename check function for 2.2.0, current one is deprecated

### DIFF
--- a/dags/tests/openshift_nightlies/test_dag.py
+++ b/dags/tests/openshift_nightlies/test_dag.py
@@ -58,7 +58,7 @@ class TestDags():
             # For every DAG object, test for cycles
             for dag in dag_objects:
                 dag.tree_view()
-                dag_cycle_tester.test_cycle(dag)
+                dag_cycle_tester.check_cycle(dag)
     
 def _import_file(module_name, module_path):
     import importlib.util


### PR DESCRIPTION
test_cycle has been renamed to check_cycle on 2.2.0

https://newreleases.io/project/github/apache/airflow/release/2.2.0
```python

==================================================================================================================================== warnings summary =====================================================================================================================================
tests/openshift_nightlies/test_dag.py: 27 warnings
  /home/morenod/Documents/airflow-kubernetes/dags/tests/openshift_nightlies/test_dag.py:64: DeprecationWarning: Deprecated, please use `check_cycle` at the same module instead.
    dag_cycle_tester.test_cycle(dag)
```
