### PR TITLE
move _generate_cluster_name function from OpenshiftInstaller class to Release

### DIFF
--- a/dags/openshift_nightlies/tasks/install/rosa/rosa.py
+++ b/dags/openshift_nightlies/tasks/install/rosa/rosa.py
@@ -7,7 +7,6 @@ from openshift_nightlies.tasks.install.openshift import AbstractOpenshiftInstall
 from openshift_nightlies.models.dag_config import DagConfig
 from openshift_nightlies.models.release import OpenshiftRelease
 
-from hashlib import md5
 import requests
 
 from airflow.operators.bash import BashOperator
@@ -22,11 +21,6 @@ class RosaInstaller(AbstractOpenshiftInstaller):
     def __init__(self, dag, config: DagConfig, release: OpenshiftRelease):
         super().__init__(dag, config, release)
         self.exec_config = executor.get_default_executor_config(self.dag_config, executor_image="airflow-managed-services")
-
-    def _generate_cluster_name(self):
-        cluster_name = super()._generate_cluster_name()
-        cluster_version = str(self.release.version).replace(".","")
-        return "airflow-"+cluster_version+"-"+md5(cluster_name.encode("ascii")).hexdigest()[:4]
 
     # Create Airflow Task for Install/Cleanup steps
     def _get_task(self, operation="install", trigger_rule="all_success"):


### PR DESCRIPTION
At his moment, function _generate_cluster_name() is located on the openshift installer class, so it cannot be used outside the installation step.

From rosa, we need to invoke this function from the benchmarks, because there is no other way to obtain the cluster name used to install the cluster

This PR moves this function from the openshift installer class to the release class, so it can be used on any step, just importing the release class (which is already imported on benckmarks at this moment).

Also cluster name generated by default it too long for ROSA installation, so based on the platform, now we can control, based on the platform, the cluster name generated.

Test for rosa: http://morenod-cluster-name-fix-airflow.apps.sailplane.perf.lab.eng.rdu2.redhat.com/log?dag_id=4.9_rosa_default&task_id=install&execution_date=2021-10-29T13%3A14%3A22.367933%2B00%3A00

Test for AWS: http://morenod-cluster-name-fix-airflow.apps.sailplane.perf.lab.eng.rdu2.redhat.com/log?dag_id=4.8_aws_default&task_id=install&execution_date=2021-10-29T13%3A55%3A20.750966%2B00%3A00
