### PR TITLE
make #nodes divisible by 3 for consistency

### DIFF
--- a/dags/openshift_nightlies/config/install/aws/ovn-large.json
+++ b/dags/openshift_nightlies/config/install/aws/ovn-large.json
@@ -3,7 +3,7 @@
     "aws_access_key_id": "",
     "aws_secret_access_key": "",
     "openshift_master_count": 3,
-    "openshift_worker_count": 250,
+    "openshift_worker_count": 252,
     "openshift_host_prefix": "22",
     "openshift_network_type": "OVNKubernetes",
     "openshift_master_instance_type": "r5.4xlarge",

--- a/dags/openshift_nightlies/config/install/aws/ovn-medium.json
+++ b/dags/openshift_nightlies/config/install/aws/ovn-medium.json
@@ -3,7 +3,7 @@
     "aws_access_key_id": "",
     "aws_secret_access_key": "",
     "openshift_master_count": 3,
-    "openshift_worker_count": 123,
+    "openshift_worker_count": 120,
     "openshift_host_prefix": "22",
     "openshift_network_type": "OVNKubernetes",
     "openshift_master_instance_type": "r5.4xlarge",

--- a/dags/openshift_nightlies/config/install/aws/ovn.json
+++ b/dags/openshift_nightlies/config/install/aws/ovn.json
@@ -3,7 +3,7 @@
     "aws_access_key_id": "",
     "aws_secret_access_key": "",
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 27,
     "openshift_host_prefix": "22",
     "openshift_network_type": "OVNKubernetes",
     "openshift_master_instance_type": "r5.4xlarge",

--- a/dags/openshift_nightlies/config/install/aws/sdn-large.json
+++ b/dags/openshift_nightlies/config/install/aws/sdn-large.json
@@ -3,7 +3,7 @@
     "aws_access_key_id": "",
     "aws_secret_access_key": "",
     "openshift_master_count": 3,
-    "openshift_worker_count": 250,
+    "openshift_worker_count": 252,
     "openshift_host_prefix": "22",
     "openshift_network_type": "OpenShiftSDN",
     "openshift_master_instance_type": "r5.4xlarge",

--- a/dags/openshift_nightlies/config/install/aws/sdn-medium.json
+++ b/dags/openshift_nightlies/config/install/aws/sdn-medium.json
@@ -3,7 +3,7 @@
     "aws_access_key_id": "",
     "aws_secret_access_key": "",
     "openshift_master_count": 3,
-    "openshift_worker_count": 123,
+    "openshift_worker_count": 120,
     "openshift_host_prefix": "22",
     "openshift_network_type": "OpenShiftSDN",
     "openshift_master_instance_type": "r5.4xlarge",

--- a/dags/openshift_nightlies/config/install/aws/sdn.json
+++ b/dags/openshift_nightlies/config/install/aws/sdn.json
@@ -3,7 +3,7 @@
     "aws_access_key_id": "",
     "aws_secret_access_key": "",
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 27,
     "openshift_host_prefix": "22",
     "openshift_network_type": "OpenShiftSDN",
     "openshift_master_instance_type": "r5.4xlarge",

--- a/dags/openshift_nightlies/config/install/azure/ovn-large.json
+++ b/dags/openshift_nightlies/config/install/azure/ovn-large.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 250,
+    "openshift_worker_count": 252,
     "openshift_base_domain": "ats.azure.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OVNKubernetes",

--- a/dags/openshift_nightlies/config/install/azure/ovn-medium.json
+++ b/dags/openshift_nightlies/config/install/azure/ovn-medium.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 123,
+    "openshift_worker_count": 120,
     "openshift_base_domain": "ats.azure.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OVNKubernetes",

--- a/dags/openshift_nightlies/config/install/azure/ovn.json
+++ b/dags/openshift_nightlies/config/install/azure/ovn.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 27,
     "openshift_base_domain": "ats.azure.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OVNKubernetes",

--- a/dags/openshift_nightlies/config/install/azure/sdn-large.json
+++ b/dags/openshift_nightlies/config/install/azure/sdn-large.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 250,
+    "openshift_worker_count": 252,
     "openshift_base_domain": "ats.azure.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OpenShiftSDN",

--- a/dags/openshift_nightlies/config/install/azure/sdn-medium.json
+++ b/dags/openshift_nightlies/config/install/azure/sdn-medium.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 123,
+    "openshift_worker_count": 120,
     "openshift_base_domain": "ats.azure.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OpenShiftSDN",

--- a/dags/openshift_nightlies/config/install/azure/sdn.json
+++ b/dags/openshift_nightlies/config/install/azure/sdn.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 27,
     "openshift_base_domain": "ats.azure.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OpenShiftSDN",

--- a/dags/openshift_nightlies/config/install/gcp/ovn-large.json
+++ b/dags/openshift_nightlies/config/install/gcp/ovn-large.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 250,
+    "openshift_worker_count": 252,
     "openshift_base_domain": "perfscale.gcp.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OVNKubernetes",

--- a/dags/openshift_nightlies/config/install/gcp/ovn-medium.json
+++ b/dags/openshift_nightlies/config/install/gcp/ovn-medium.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 123,
+    "openshift_worker_count": 120,
     "openshift_base_domain": "perfscale.gcp.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OVNKubernetes",

--- a/dags/openshift_nightlies/config/install/gcp/ovn.json
+++ b/dags/openshift_nightlies/config/install/gcp/ovn.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 27,
     "openshift_base_domain": "perfscale.gcp.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OVNKubernetes",

--- a/dags/openshift_nightlies/config/install/gcp/sdn-large.json
+++ b/dags/openshift_nightlies/config/install/gcp/sdn-large.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 250,
+    "openshift_worker_count": 252,
     "openshift_base_domain": "perfscale.gcp.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OpenShiftSDN",

--- a/dags/openshift_nightlies/config/install/gcp/sdn-medium.json
+++ b/dags/openshift_nightlies/config/install/gcp/sdn-medium.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 123,
+    "openshift_worker_count": 120,
     "openshift_base_domain": "perfscale.gcp.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OpenShiftSDN",

--- a/dags/openshift_nightlies/config/install/gcp/sdn.json
+++ b/dags/openshift_nightlies/config/install/gcp/sdn.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 27,
     "openshift_base_domain": "perfscale.gcp.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OpenShiftSDN",


### PR DESCRIPTION
### Description

- Common deployment: 27 nodes
- Medium: 120 nodes
- Large: 252 nodes

i.e divisible by 3 for managed and unmanaged clouds to be consistent

- For common deployment the initial scale was 3, now changed to 27
- ACS stays at 3 nodes
- No medium and large for ROSA as of now
