### PR TITLE
Increase ROSA clusters expiration to 2 days

### DIFF
--- a/dags/openshift_nightlies/tasks/install/rosa/defaults.json
+++ b/dags/openshift_nightlies/tasks/install/rosa/defaults.json
@@ -32,5 +32,5 @@
     "daemon_mode": true,
     "fips": false,
     "rosa_installation_method": "rosa",
-    "rosa_expiration_time": "1440m"
+    "rosa_expiration_time": "2880m"
 }


### PR DESCRIPTION
ROSA clusters are automatically deleted after some time.

Increasing that time to 2 days, because it seems that 1 day is not enough
