### PR TITLE
Split out uperf runs into separate tasks

### DIFF
--- a/dags/openshift_nightlies/config/baremetal-benchmarks/install-bench.json
+++ b/dags/openshift_nightlies/config/baremetal-benchmarks/install-bench.json
@@ -1,7 +1,7 @@
 {
     "benchmarks": [      
         {
-            "name": "uperf_pod_network",
+            "name": "uperf-pod-network",
             "workload": "network-perf",
             "command": "./run_pod_network_test_fromgit.sh test_cloud",
             "env": {

--- a/dags/openshift_nightlies/config/baremetal-benchmarks/scaleup-bench.json
+++ b/dags/openshift_nightlies/config/baremetal-benchmarks/scaleup-bench.json
@@ -1,7 +1,7 @@
 {
     "benchmarks": [
         {
-            "name": "uperf_serviceip_network",
+            "name": "uperf-serviceip-network",
             "workload": "network-perf",
             "command": "./run_serviceip_network_test_fromgit.sh test_cloud",
             "env": {
@@ -11,7 +11,7 @@
             }
         },
         {
-            "name": "node_density",
+            "name": "node-density",
             "workload": "kube-burner",
             "command": "./run_nodedensity_test_fromgit.sh test_cloud",
             "env": {
@@ -29,7 +29,7 @@
             }
         },
 	{
-	    "name": "cluster_density",
+	    "name": "cluster-density",
 	    "workload": "kube-burner",
 	    "command": "./run_clusterdensity_test_fromgit.sh test_cloud",
 	    "env": {
@@ -46,7 +46,7 @@
             }
         },
 	{
-	    "name": "max_namespaces",
+	    "name": "max-namespaces",
 	    "workload": "kube-burner",
 	    "command": "./run_maxnamespaces_test_fromgit.sh test_cloud",
 	    "env": {
@@ -63,7 +63,7 @@
             }
 	},
     	{
-	    "name": "max_services",
+	    "name": "max-services",
 	    "workload": "kube-burner",
 	    "command": "./run_maxservices_test_fromgit.sh test_cloud",
 	    "env": {
@@ -80,7 +80,7 @@
             }
 	},
     	{
-	    "name": "pod_density",
+	    "name": "pod-density",
 	    "workload": "kube-burner",
 	    "command": "./run_poddensity_test_fromgit.sh test_cloud",
 	    "env": {

--- a/dags/openshift_nightlies/config/benchmarks/acs.json
+++ b/dags/openshift_nightlies/config/benchmarks/acs.json
@@ -6,7 +6,7 @@
             "command": "./baseline_perf.sh"
         },
         {
-            "name": "scale_25",
+            "name": "scale-25",
             "workload": "scale-perf",
             "command": "./run_scale_fromgit.sh",
             "env": {
@@ -16,7 +16,7 @@
             }
         },
         {
-            "name": "cluster_density",
+            "name": "cluster-density",
             "workload": "kube-burner",
             "command": "./run_clusterdensity_test_fromgit.sh",
             "env": {
@@ -35,7 +35,7 @@
             }
         },
         {
-            "name": "node_density",
+            "name": "node-density",
             "workload": "kube-burner",
             "command": "./run_nodedensity_test_fromgit.sh",
             "env": {
@@ -55,7 +55,7 @@
             }
         },
         {
-            "name": "scale_50",
+            "name": "scale-50",
             "workload": "scale-perf",
             "command": "./run_scale_fromgit.sh",
             "env": {
@@ -65,7 +65,7 @@
             }
         },
         {
-            "name": "cluster_density_50",
+            "name": "cluster-density-50",
             "workload": "kube-burner",
             "command": "./run_clusterdensity_test_fromgit.sh",
             "env": {
@@ -84,7 +84,7 @@
             }
         },
         {
-            "name": "host_network",
+            "name": "host-network",
             "workload": "network-perf",
             "command": "./run_hostnetwork_network_test_fromgit.sh test_cloud",
             "env": {
@@ -97,7 +97,7 @@
             }
         },
         {
-            "name": "pod_network",
+            "name": "pod-network",
             "workload": "network-perf",
             "command": "./run_pod_network_test_fromgit.sh test_cloud",
             "env": {
@@ -110,7 +110,7 @@
             }
         },
         {
-            "name": "serviceip_network",
+            "name": "serviceip-network",
             "workload": "network-perf",
             "command": "./run_serviceip_network_test_fromgit.sh test_cloud",
             "env": {
@@ -123,7 +123,7 @@
             }
         },
         {
-            "name": "scale_down_25",
+            "name": "scale-down-25",
             "workload": "scale-perf",
             "command": "./run_scale_fromgit.sh",
             "env": {
@@ -148,7 +148,7 @@
             }
         },
         {
-            "name": "load_cluster_preupgrade",
+            "name": "load-cluster-preupgrade",
             "workload": "kube-burner",
             "command": "./run_clusterdensity_test_fromgit.sh",
             "env": {

--- a/dags/openshift_nightlies/config/benchmarks/control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/control-plane.json
@@ -6,7 +6,7 @@
             "command": "./baseline_perf.sh"            
         },      
         {
-            "name": "node_density",
+            "name": "node-density",
             "workload": "kube-burner",
             "command": "./run_nodedensity_test_fromgit.sh",
             "env": {
@@ -25,7 +25,7 @@
             }
         },
         {
-            "name": "node_density_heavy",
+            "name": "node-density-heavy",
             "workload": "kube-burner",
             "command": "./run_nodedensity-heavy_test_fromgit.sh",
             "env": {
@@ -44,7 +44,7 @@
             }
         },
         {
-            "name": "cluster_density",
+            "name": "cluster-density",
             "workload": "kube-burner",
             "command": "./run_clusterdensity_test_fromgit.sh",
             "env": {
@@ -62,7 +62,7 @@
             }
         },
         {
-            "name": "load_cluster_preupgrade",
+            "name": "load-cluster-preupgrade",
             "workload": "kube-burner",
             "command": "./run_clusterdensity_test_fromgit.sh",
             "env": {

--- a/dags/openshift_nightlies/config/benchmarks/data-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/data-plane.json
@@ -3,40 +3,64 @@
         {
             "name": "host_network",
             "workload": "network-perf",
-            "command": "./run_hostnetwork_network_test_fromgit.sh test_cloud",
+            "command": "./run.sh",
             "env": {
-                "COMPARE": "true",
-                "GOLD_SDN": "openshiftsdn",
-                "COMPARE_WITH_GOLD": "true",
-                "EMAIL_ID_FOR_RESULTS_SHEET": "msheth@redhat.com",
-                "GSHEET_KEY_LOCATION": "/tmp/key.json",
-                "ENABLE_SNAPPY_BACKUP": "true"
+                "WORKLOAD": "hostnet",
+                "PAIRS": "1"
             }
         },
         {
-            "name": "pod_network",
+            "name": "pod_network_1p",
             "workload": "network-perf",
-            "command": "./run_pod_network_test_fromgit.sh test_cloud",
+            "command": "./run.sh",
             "env": {
-                "COMPARE": "true",
-                "GOLD_SDN": "openshiftsdn",
-                "COMPARE_WITH_GOLD": "true",
-                "EMAIL_ID_FOR_RESULTS_SHEET": "msheth@redhat.com",
-                "GSHEET_KEY_LOCATION": "/tmp/key.json",
-                "ENABLE_SNAPPY_BACKUP": "true"
+                "WORKLOAD": "pod",
+                "PAIRS": "1"
             }
         },
         {
-            "name": "serviceip_network",
+            "name": "pod_network_2p",
             "workload": "network-perf",
-            "command": "./run_serviceip_network_test_fromgit.sh test_cloud",
+            "command": "./run.sh",
             "env": {
-                "COMPARE": "true",
-                "GOLD_SDN": "openshiftsdn",
-                "COMPARE_WITH_GOLD": "true",
-                "EMAIL_ID_FOR_RESULTS_SHEET": "msheth@redhat.com",
-                "GSHEET_KEY_LOCATION": "/tmp/key.json",
-                "ENABLE_SNAPPY_BACKUP": "true"
+                "WORKLOAD": "pod",
+                "PAIRS": "2"
+            }
+        },
+        {
+            "name": "pod_network_4p",
+            "workload": "network-perf",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "pod",
+                "PAIRS": "4"
+            }
+        },
+        {
+            "name": "serviceip_network_1p",
+            "workload": "network-perf",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "service",
+                "PAIRS": "1"
+            }
+        },
+        {
+            "name": "serviceip_network_2p",
+            "workload": "network-perf",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "service",
+                "PAIRS": "2"
+            }
+        },
+        {
+            "name": "serviceip_network_4p",
+            "workload": "network-perf",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "service",
+                "PAIRS": "4"
             }
         },
         {

--- a/dags/openshift_nightlies/config/benchmarks/data-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/data-plane.json
@@ -1,7 +1,7 @@
 {
     "benchmarks": [
         {
-            "name": "host_network",
+            "name": "host-network",
             "workload": "network-perf",
             "command": "./run.sh",
             "env": {
@@ -10,7 +10,7 @@
             }
         },
         {
-            "name": "pod_network_1p",
+            "name": "pod-network-1p",
             "workload": "network-perf",
             "command": "./run.sh",
             "env": {
@@ -19,7 +19,7 @@
             }
         },
         {
-            "name": "pod_network_2p",
+            "name": "pod-network-2p",
             "workload": "network-perf",
             "command": "./run.sh",
             "env": {
@@ -28,7 +28,7 @@
             }
         },
         {
-            "name": "pod_network_4p",
+            "name": "pod-network-4p",
             "workload": "network-perf",
             "command": "./run.sh",
             "env": {
@@ -37,7 +37,7 @@
             }
         },
         {
-            "name": "serviceip_network_1p",
+            "name": "serviceip-network-1p",
             "workload": "network-perf",
             "command": "./run.sh",
             "env": {
@@ -46,7 +46,7 @@
             }
         },
         {
-            "name": "serviceip_network_2p",
+            "name": "serviceip-network-2p",
             "workload": "network-perf",
             "command": "./run.sh",
             "env": {
@@ -55,7 +55,7 @@
             }
         },
         {
-            "name": "serviceip_network_4p",
+            "name": "serviceip-network-4p",
             "workload": "network-perf",
             "command": "./run.sh",
             "env": {

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
@@ -6,7 +6,7 @@
             "command": "./baseline_perf.sh"            
         },      
         {
-            "name": "node_density",
+            "name": "node-density",
             "workload": "kube-burner",
             "command": "./run_nodedensity_test_fromgit.sh",
             "env": {
@@ -25,7 +25,7 @@
             }
         },
         {
-            "name": "node_density_heavy",
+            "name": "node-density-heavy",
             "workload": "kube-burner",
             "command": "./run_nodedensity-heavy_test_fromgit.sh",
             "env": {
@@ -44,7 +44,7 @@
             }
         },
         {
-            "name": "cluster_density",
+            "name": "cluster-density",
             "workload": "kube-burner",
             "command": "./run_clusterdensity_test_fromgit.sh",
             "env": {

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
@@ -6,7 +6,7 @@
             "command": "./baseline_perf.sh"            
         },      
         {
-            "name": "node_density",
+            "name": "node-density",
             "workload": "kube-burner",
             "command": "./run_nodedensity_test_fromgit.sh",
             "env": {
@@ -25,7 +25,7 @@
             }
         },
         {
-            "name": "node_density_heavy",
+            "name": "node-density-heavy",
             "workload": "kube-burner",
             "command": "./run_nodedensity-heavy_test_fromgit.sh",
             "env": {
@@ -44,7 +44,7 @@
             }
         },
         {
-            "name": "cluster_density",
+            "name": "cluster-density",
             "workload": "kube-burner",
             "command": "./run_clusterdensity_test_fromgit.sh",
             "env": {
@@ -62,7 +62,7 @@
             }
         },
         {
-            "name": "load_cluster_preupgrade",
+            "name": "load-cluster-preupgrade",
             "workload": "kube-burner",
             "command": "./run_clusterdensity_test_fromgit.sh",
             "env": {

--- a/dags/openshift_nightlies/config/benchmarks/openstack.json
+++ b/dags/openshift_nightlies/config/benchmarks/openstack.json
@@ -6,7 +6,7 @@
             "command": "./baseline_perf.sh"            
         },
         {
-            "name": "scale_25",
+            "name": "scale-25",
             "workload": "scale-perf",
             "command": "./run_scale_fromgit.sh",
             "env": {
@@ -16,7 +16,7 @@
             }
         },
         {
-            "name": "cluster_density",
+            "name": "cluster-density",
             "workload": "kube-burner",
             "command": "./run_clusterdensity_test_fromgit.sh",
             "env": {
@@ -33,7 +33,7 @@
             }
         },
         {
-            "name": "node_density",
+            "name": "node-density",
             "workload": "kube-burner",
             "command": "./run_nodedensity_test_fromgit.sh",
             "env": {
@@ -51,7 +51,7 @@
             }
         },
         {
-            "name": "scale_50",
+            "name": "scale-50",
             "workload": "scale-perf",
             "command": "./run_scale_fromgit.sh",
             "env": {
@@ -61,7 +61,7 @@
             }
         },
         {
-            "name": "cluster_density_50",
+            "name": "cluster-density-50",
             "workload": "kube-burner",
             "command": "./run_clusterdensity_test_fromgit.sh",
             "env": {
@@ -78,7 +78,7 @@
             }
         },
         {
-            "name": "host_network",
+            "name": "host-network",
             "workload": "network-perf",
             "command": "./run_hostnetwork_network_test_fromgit.sh test_cloud",
             "env": {
@@ -89,7 +89,7 @@
             }
         },
         {
-            "name": "pod_network",
+            "name": "pod-network",
             "workload": "network-perf",
             "command": "./run_pod_network_test_fromgit.sh test_cloud",
             "env": {
@@ -100,7 +100,7 @@
             }
         },
         {
-            "name": "serviceip_network",
+            "name": "serviceip-network",
             "workload": "network-perf",
             "command": "./run_serviceip_network_test_fromgit.sh test_cloud",
             "env": {
@@ -111,7 +111,7 @@
             }
         },
         {
-            "name": "scale_down_25",
+            "name": "scale-down-25",
             "workload": "scale-perf",
             "command": "./run_scale_fromgit.sh",
             "env": {

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -27,8 +27,8 @@ dagConfig:
     tag: 2.2.0
   dependencies:
     e2e_benchmarking:
-      repo: https://github.com/cloud-bulldozer/e2e-benchmarking.git
-      branch: master
+      repo: https://github.com/whitleykeith/e2e-benchmarking.git
+      branch: uperf-single-run
 
 platforms:
   cloud:

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -27,8 +27,8 @@ dagConfig:
     tag: 2.2.0
   dependencies:
     e2e_benchmarking:
-      repo: https://github.com/whitleykeith/e2e-benchmarking.git
-      branch: uperf-single-run
+      repo: https://github.com/cloud-bulldozer/e2e-benchmarking.git
+      branch: master
 
 platforms:
   cloud:

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -83,7 +83,8 @@ else
     cd /home/airflow/workspace
     ls
     cd e2e-benchmarking/workloads/$workload
-    export UUID=$(uuidgen)
+    export UUID=$AIRFLOW_CTX_TASK_ID-$(date '+%Y%m%d')-$(uuidgen | head -c16)
+    
     eval "$command"
     benchmark_rv=$?
 

--- a/dags/openshift_nightlies/tasks/index/status.py
+++ b/dags/openshift_nightlies/tasks/index/status.py
@@ -52,7 +52,7 @@ class StatusIndexer():
             command = f'{constants.root_dag_dir}/scripts/index.sh '
     
         return BashOperator(
-            task_id=f"index_{self.task}",
+            task_id=f"index-{self.task}",
             depends_on_past=False,
             bash_command=command,
             retries=3,


### PR DESCRIPTION
Depends on: https://github.com/cloud-bulldozer/e2e-benchmarking/pull/296

Split out the uperf runs for data plane tests. This fixes issues with task metadata not being present for certain uperf runs as well as making it easier to derive results in reports. 