### PR TITLE
Update cluster name for ROSA as 4.10 exceeds max chars

### DIFF
--- a/dags/openshift_nightlies/models/release.py
+++ b/dags/openshift_nightlies/models/release.py
@@ -45,8 +45,9 @@ class OpenshiftRelease:
         else:
             cluster_name = f"{git_user}-{release_name}"
         if self.platform == 'rosa' or self.platform == 'rogcp':
+            #Only 15 chars are allowed
             cluster_version = str(self.version).replace(".","")
-            return "airflow-"+cluster_version+"-"+md5(cluster_name.encode("ascii")).hexdigest()[:4]
+            return "perf-"+cluster_version+"-"+md5(cluster_name.encode("ascii")).hexdigest()[:4]
         else:
             return cluster_name
     


### PR DESCRIPTION
On 4.10 installations, cluster name airflow-410-53f6 exceeds cluster max number of chars.

Modified to perf-410-XXXX so we have some free chars
