### PR TITLE
Update UUID gen expression

### DIFF
--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -83,7 +83,7 @@ else
     cd /home/airflow/workspace
     ls
     cd e2e-benchmarking/workloads/$workload
-    export UUID=$AIRFLOW_CTX_TASK_ID-$(date '+%Y%m%d')-$(uuidgen | head -c16)
+    export UUID=$(uuidgen | head -c16)-$AIRFLOW_CTX_TASK_ID-$(date '+%Y%m%d')
     
     eval "$command"
     benchmark_rv=$?


### PR DESCRIPTION
The first part of the UUID is now the results of uuidgen instead of the task name. Using the task name is problematic since for example, kube-burner jobs name are generated with the expression:
`name: kube-burner-{{ trunc_uuid }}`

This trunc_uuid is similar in the node-density and node-density-heavy
benchmarks. (Jobs created here are named kube-burner-node). Running both bencharks in a row It's not possible, since we can't create two jobs with the same name.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

### Fixes

Node-density-heavy benchmark can't run after running node-density.
