### PR TITLE
Add clustername as DAG Tag

### DIFF
--- a/dags/openshift_nightlies/dag.py
+++ b/dags/openshift_nightlies/dag.py
@@ -51,6 +51,7 @@ class AbstractOpenshiftNightlyDAG(ABC):
         tags.append(self.release.release_stream)
         tags.append(self.release.variant)
         tags.append(self.release.version_alias)
+        tags.append(self.release._generate_cluster_name())
 
         self.dag = DAG(
             self.release_name,


### PR DESCRIPTION
Cluster Names are not descriptives when working with ROSA/ARO/ROGCP, because default cluster name exceds the char limit, and we need to create cluster with names as perf-410-b3ec or perf-49-ad41.

This commit adds this cluster name as tag, so we can easily identify the cluster created on each DAG:

![image](https://user-images.githubusercontent.com/25103450/150509433-9e9a6ff2-5c69-42db-9bef-8019fd769958.png)

