### PR TITLE
Do not require all platforms

### DIFF
--- a/dags/openshift_nightlies/util/manifest.py
+++ b/dags/openshift_nightlies/util/manifest.py
@@ -149,11 +149,16 @@ class Manifest():
 
 
     def get_releases(self):
-        self.get_cloud_releases()
-        self.get_baremetal_releases()
-        self.get_openstack_releases()
-        self.get_rosa_releases()
-        self.get_rogcp_releases()
+        if 'cloud' in self.yaml['platforms']:
+            self.get_cloud_releases()
+        if 'baremetal' in self.yaml['platforms']:
+            self.get_baremetal_releases()
+        if 'openstack' in self.yaml['platforms']:
+            self.get_openstack_releases()
+        if 'rosa' in self.yaml['platforms']:
+            self.get_rosa_releases()
+        if 'rogcp' in self.yaml['platforms']:
+            self.get_rogcp_releases()
         return self.releases
 
     def _get_dependencies(self):


### PR DESCRIPTION
Currently even if not used, all platforms need to be defined
in the manifest.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
