### PR TITLE
Slack Integration for Airflow CI

### DIFF
--- a/dags/openshift_nightlies/models/dag_config.py
+++ b/dags/openshift_nightlies/models/dag_config.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Optional
 from datetime import timedelta, datetime
+from openshift_nightlies.util import slack_integration
 
 @dataclass
 class DagConfig:
@@ -14,6 +15,7 @@ class DagConfig:
             'email_on_failure': False,
             'email_on_retry': False,
             'retries': 1,
+            'on_failure_callback': slack_integration.task_fail_slack_alert,
             'retry_delay': timedelta(minutes=5)
         })
     executor_image: Optional[dict] = field(default_factory=lambda: {

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -1,0 +1,25 @@
+from airflow.hooks.base_hook import BaseHook
+from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
+SLACK_CONN_ID = 'slack'
+def task_fail_slack_alert(context):
+    slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
+    slack_msg = """
+            :red_circle: Task Failed. 
+            *Task*: {task}  
+            *Dag*: {dag} 
+            *Execution Time*: {exec_date}  
+            *Log Url*: {log_url} 
+            """.format(
+            task=context.get('task_instance').task_id,
+            dag=context.get('task_instance').dag_id,
+            ti=context.get('task_instance'),
+            exec_date=context.get('execution_date'),
+            log_url=context.get('task_instance').log_url,
+        )
+    failed_alert = SlackWebhookOperator(
+        task_id='slack_test',
+        http_conn_id='slack',
+        webhook_token=slack_webhook_token,
+        message=slack_msg,
+        username='airflow')
+    return failed_alert.execute(context=context)

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -1,5 +1,5 @@
-from airflow.hooks.base_hook import BaseHook
-from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
+from airflow.hooks.base import BaseHook
+from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
 SLACK_CONN_ID = 'slack'
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password

--- a/dags/setup.cfg
+++ b/dags/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     apache-airflow
     prometheus-api-client
     elasticsearch
+    apache-airflow-providers-slack
 python_requires = >=3.8
 
 [options.extras_require]


### PR DESCRIPTION
### Description
This change allows for real time updates of the airflow CI for any task failures on the designated slack channel.
A slack webhook is configured to handle the interaction.
Example of a task failure message:
```
AirflowAPP  12:49 PM
:red_circle: Task Failed.
           Task: baseline  
           Dag: 4.10-aws-sdn-control-plane
           Execution Time: 2022-01-26T06:25:53.123396+00:00  
           Log Url: http://harshith-umesh-slack-airflow.apps.sailplane.perf.lab.eng.rdu2.redhat.com/log?execution_date=2022-01-26T06%3A25%3A53.123396%2B00%3A00&task_id=baseline&dag_id=4.10-aws-sdn-control-plane 
```

