### PR TITLE
Enable consuming ocm-cli master branch + OVN

### DIFF
--- a/dags/openshift_nightlies/config/install/rogcp/ovn.json
+++ b/dags/openshift_nightlies/config/install/rogcp/ovn.json
@@ -3,7 +3,7 @@
     "ocm_environment": "stage",
     "openshift_worker_count": 27,
     "ocm_cli_version": "master",
-    "openshift_network_type": "OpenShiftSDN",
+    "openshift_network_type": "OVNKubernetes",
     "openshift_worker_instance_type": "custom-8-32768",
     "machineset_metadata_label_prefix": "machine.openshift.io",
     "openshift_workload_node_instance_type": "custom-16-65536"

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -160,3 +160,14 @@ platforms:
         config: 
           install: None
           benchmarks: data-plane.json
+      - name: ovn-control-plane
+        schedule:  "0 12 * * 1,3,5"
+        config:
+          install: rogcp/ovn.json
+          benchmarks: control-plane.json
+      - name: ovn-data-plane
+        schedule: "0 12 * * 1"
+        config:
+          install: rogcp/ovn.json
+          benchmarks: data-plane.json
+


### PR DESCRIPTION
This would help us improve the velocity of testing by removing
the need to wait for tagged releases.

This commit also enables support for OVNKUbernetes in OSD GCP Clusters

This needs to merge after https://github.com/openshift-online/ocm-cli/pull/352
is merged.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
