### PR TITLE
Enable 4.11 releases

### DIFF
--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -28,7 +28,7 @@ dagConfig:
 
 platforms:
   cloud:
-    versions: [4.9, "4.10"]
+    versions: [4.9, "4.10", 4.11]
     providers: ["aws", "gcp", "azure"]
     variants: 
     - name: sdn-control-plane
@@ -98,7 +98,7 @@ platforms:
           benchmarks: openstack.json
 
   rosa:
-    versions: [4.9, "4.10"]
+    versions: [4.9, "4.10", 4.11]
     variants:
       - name: sdn-control-plane
         schedule:  "0 12 * * 1,3,5"
@@ -121,7 +121,7 @@ platforms:
           install: rosa/ovn.json
           benchmarks: data-plane.json
   rogcp:
-    versions: [4.9, "4.10"]
+    versions: [4.9, "4.10", 4.11]
     variants:
       - name: sdn-control-plane
         schedule:  "0 12 * * 1,3,5"

--- a/images/airflow-managed-services/Dockerfile
+++ b/images/airflow-managed-services/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.2.0
+ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.2.3
 FROM ${BASE_IMAGE} as runtime
 USER root
 RUN curl -L https://go.dev/dl/go1.17.6.linux-amd64.tar.gz -o go1.17.6.linux-amd64.tar.gz


### PR DESCRIPTION
Manifest changes to include new nightly releases for managed service clusters.