### PR TITLE
Add python 3.9, required by gcloud

### DIFF
--- a/dags/openshift_nightlies/scripts/install/ocm_gcp.sh
+++ b/dags/openshift_nightlies/scripts/install/ocm_gcp.sh
@@ -51,6 +51,7 @@ setup(){
     export ROSA_TOKEN=$(cat ${json_file} | jq -r .rosa_token_${ROSA_ENVIRONMENT})
     export CLUSTER_NAME=$(cat ${json_file} | jq -r .openshift_cluster_name)
     echo ${GCP_MANAGED_SERVICES_TOKEN} > ./serviceAccount.json
+    export CLOUDSDK_PYTHON=python3.9
     ocm login --url=https://api.stage.openshift.com --token="${ROSA_TOKEN}"
     gcloud config set account osd-ccs-admin@openshift-perfscale.iam.gserviceaccount.com
     gcloud auth activate-service-account osd-ccs-admin@openshift-perfscale.iam.gserviceaccount.com --key-file ./serviceAccount.json

--- a/images/airflow-managed-services/Dockerfile
+++ b/images/airflow-managed-services/Dockerfile
@@ -11,12 +11,15 @@ RUN mv $GOPATH/bin/pkger /usr/local/bin/
 ENV GOFLAGS=
 RUN apt update -y
 RUN apt upgrade -y
-RUN apt install jq unzip bsdmainutils -y
+RUN apt install jq unzip bsdmainutils build-essential libncurses5-dev zlib1g-dev libnss3-dev libgdbm-dev libssl-dev libsqlite3-dev libffi-dev libreadline-dev curl libbz2-dev -y
 RUN curl -L $(curl -s https://api.github.com/repos/openshift/rosa/releases/latest | jq -r ".assets[] | select(.name == \"rosa-linux-amd64\") | .browser_download_url") --output /usr/local/bin/rosa
 RUN curl -L $(curl -s https://api.github.com/repos/openshift-online/ocm-cli/releases/latest | jq -r ".assets[] | select(.name == \"ocm-linux-amd64\") | .browser_download_url") --output /usr/local/bin/ocm
 RUN chmod +x /usr/local/bin/rosa && chmod +x /usr/local/bin/ocm
 RUN /usr/local/bin/rosa download openshift-client
 RUN tar xzvf openshift-client-linux.tar.gz
+RUN curl "https://www.python.org/ftp/python/3.9.9/Python-3.9.9.tar.xz" | tar xJf -
+RUN cd Python-3.9.9 && ./configure --enable-optimizations && make && make altinstall
+RUN echo "export CLOUDSDK_PYTHON=python3.9" >> /home/airflow/.bashrc
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
 RUN mv oc kubectl /usr/local/bin/
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"


### PR DESCRIPTION
Exporting the var in the bashrc file is not enough, probably because airflow is not running from any shell. adding to the install script to force it usage