### PR TITLE
Enhance slack notifications integration

### DIFF
--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -27,9 +27,9 @@ def alert_members(context):
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    #if get_git_user() != "cloud-bulldozer":
-    #    print("Task Failed")
-    #    return
+    if get_git_user() != "cloud-bulldozer":
+        print("Task Failed")
+        return
     if "index" in context.get('task_instance').task_id:
         print("Index Task Failed")
         return

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -14,31 +14,22 @@ def get_git_user():
 
 
 def alert_members(context):
-    if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id:
-        members=" @harshith @morenod @dry @asagtani @humesh"
-    elif "aws" in context.get('task_instance').dag_id:
-        members=" @mohit @rsevilla @asagtani"
+    if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id or "-aro-" in context.get('task_instance').dag_id:
+        members=" @hperfscale-managed-services-team" 
+    elif "aws" in context.get('task_instance').dag_id or "azure" in context.get('task_instance').dag_id or "-gcp-" in context.get('task_instance').dag_id or "baremetal" in context.get('task_instance').dag_id:
+        members=" @perfscale-team-core"
     elif "openstack" in context.get('task_instance').dag_id:
         members=" @asagtani @masco"
-    elif "azure" in context.get('task_instance').dag_id:
-        members=" @mohit @rsevilla @asagtani"
-    elif "-gcp-" in context.get('task_instance').dag_id:
-        members=" @humesh"
-    elif "baremetal" in context.get('task_instance').dag_id:
-        members=" @mohit @rsevilla @asagtani"
-    elif "chaos" in context.get('task_instance').dag_id:
-        members=""
     else:
         members=""
-    return members
-            
+    return members            
 
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    if get_git_user() != "cloud-bulldozer":
-        print("Task Failed")
-        return
+    #if get_git_user() != "cloud-bulldozer":
+    #    print("Task Failed")
+    #    return
     if "index" in context.get('task_instance').task_id:
         print("Index Task Failed")
         return

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -6,7 +6,7 @@ SLACK_CONN_ID = 'slack'
 
 def alert_members(context):
     if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id:
-        members=" @morenod @dry"
+        members=" @harshith @morenod @dry @asagtani"
     elif "aws" in context.get('task_instance').dag_id:
         members=" @mohit @rsevilla @asagtani"
     elif "openstack" in context.get('task_instance').dag_id:

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -1,8 +1,17 @@
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
 import logging
-#import openshift_nightlies.util.var_loader 
+from os import environ
+
 SLACK_CONN_ID = 'slack'
+
+# Used to get the git user for the repo the dags live in. 
+def get_git_user():
+    git_repo = environ['GIT_REPO']
+    git_path = git_repo.split("https://github.com/")[1]
+    git_user = git_path.split('/')[0]
+    return git_user.lower()
+
 
 def alert_members(context):
     if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id:
@@ -14,7 +23,7 @@ def alert_members(context):
     elif "azure" in context.get('task_instance').dag_id:
         members=" @mohit @rsevilla @asagtani"
     elif "-gcp-" in context.get('task_instance').dag_id:
-        members=" @mohit @rsevilla @asagtani"
+        members=" @humesh"
     elif "baremetal" in context.get('task_instance').dag_id:
         members=" @mohit @rsevilla @asagtani"
     elif "chaos" in context.get('task_instance').dag_id:
@@ -22,17 +31,17 @@ def alert_members(context):
     else:
         members=""
     return members
-    
-
-
-        
+            
 
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    #if var_loader.get_git_user() != "cloud-bulldozer":
-    #    print("Task Failed")
-    #    return 
+    if get_git_user() != "cloud-bulldozer":
+        print("Task Failed")
+        return
+    if "index" in context.get('task_instance').task_id:
+        print("Index Task Failed")
+        return
    
     slack_msg = """
             :red_circle: Task Failed {mem} 

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -18,7 +18,7 @@ def alert_members(context):
     return members    
 
 def get_hyperlink(context):
-    link= r'{"blocks":[{"type": "section","text":{"type": "mrkdwn","text":'+"<{0}|Dag Link>".format(context.get('task_instance').log_url)+'"}}]}'
+    link= "<{0}|Dag Link>".format(context.get('task_instance').log_url)
     return str(link)        
 
 

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -4,7 +4,7 @@ import logging
 SLACK_CONN_ID = 'slack'
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    logging.warning(f'{slack_webhook_token}')
+    logging.warning(f'slack token = {slack_webhook_token}')
     slack_msg = """
             :red_circle: Task Failed. 
             *Task*: {task}  

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -1,8 +1,10 @@
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
+import logging
 SLACK_CONN_ID = 'slack'
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
+    logging.warning(f'{slack_webhook_token}')
     slack_msg = """
             :red_circle: Task Failed. 
             *Task*: {task}  

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -17,7 +17,7 @@ def alert_members(context):
     if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id or "-aro-" in context.get('task_instance').dag_id:
         members=" @perfscale-managed-services-team" 
     elif "aws" in context.get('task_instance').dag_id or "azure" in context.get('task_instance').dag_id or "-gcp-" in context.get('task_instance').dag_id or "baremetal" in context.get('task_instance').dag_id:
-        members=" @perfscale-team-core"
+        members=" @perfscale-core-team"
     elif "openstack" in context.get('task_instance').dag_id:
         members=" @asagtani @masco"
     else:

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -1,7 +1,7 @@
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
 import logging
-import openshift_nightlies.util.var_loader 
+#import openshift_nightlies.util.var_loader 
 SLACK_CONN_ID = 'slack'
 
 def alert_members(context):

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -18,7 +18,8 @@ def alert_members(context):
     return members    
 
 def get_hyperlink(context):
-    return '{"blocks":[{"type": "section","text":{"type": "mrkdwn","text": "<{0}|Dag Link>"}}]}'.format(context.get('task_instance').log_url)        
+    link= '{"blocks":[{"type": "section","text":{"type": "mrkdwn","text": "<{0}|Dag Link>"}}]}'.format(context.get('task_instance').log_url)
+    return str(link)        
 
 
 def task_fail_slack_alert(context):

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -6,7 +6,7 @@ SLACK_CONN_ID = 'slack'
 
 def alert_members(context):
     if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id:
-        members=" @harshith @morenod @dry @asagtani"
+        members=" @harshith @morenod @dry @asagtani @humesh"
     elif "aws" in context.get('task_instance').dag_id:
         members=" @mohit @rsevilla @asagtani"
     elif "openstack" in context.get('task_instance').dag_id:

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -9,7 +9,7 @@ SLACK_CONN_ID = 'slack'
 def alert_members(context):
     if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id or "-aro-" in context.get('task_instance').dag_id:
         members=" @perfscale-managed-services-team" 
-    elif "awsf" in context.get('task_instance').dag_id or "azure" in context.get('task_instance').dag_id or "-gcp-" in context.get('task_instance').dag_id or "baremetal" in context.get('task_instance').dag_id:
+    elif "aws" in context.get('task_instance').dag_id or "azure" in context.get('task_instance').dag_id or "-gcp-" in context.get('task_instance').dag_id or "baremetal" in context.get('task_instance').dag_id:
         members=" @perfscale-core-team"
     elif "openstack" in context.get('task_instance').dag_id:
         members=" @asagtani @masco"
@@ -24,9 +24,9 @@ def get_hyperlink(context):
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    #if var_loader.get_git_user() != "cloud-bulldozer":
-    #    print("Task Failed")
-    #    return
+    if var_loader.get_git_user() != "cloud-bulldozer":
+        print("Task Failed")
+        return
     if "index" in context.get('task_instance').task_id:
         print("Index Task Failed")
         return

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -1,7 +1,7 @@
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
 import logging
-from openshift_nightlies.util import var_loader
+import openshift_nightlies.util.var_loader 
 SLACK_CONN_ID = 'slack'
 
 def alert_members(context):

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -15,7 +15,7 @@ def get_git_user():
 
 def alert_members(context):
     if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id or "-aro-" in context.get('task_instance').dag_id:
-        members=" @hperfscale-managed-services-team" 
+        members=" @perfscale-managed-services-team" 
     elif "aws" in context.get('task_instance').dag_id or "azure" in context.get('task_instance').dag_id or "-gcp-" in context.get('task_instance').dag_id or "baremetal" in context.get('task_instance').dag_id:
         members=" @perfscale-team-core"
     elif "openstack" in context.get('task_instance').dag_id:

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -1,12 +1,41 @@
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
 import logging
+from openshift_nightlies.util import var_loader
 SLACK_CONN_ID = 'slack'
+
+def alert_members(context):
+    if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id:
+        members="@morenod @dry"
+    elif "aws" in context.get('task_instance').dag_id:
+        members="@mohit @rsevilla @asagtani"
+    elif "openstack" in context.get('task_instance').dag_id:
+        members="@asagtani @masco"
+    elif "azure" in context.get('task_instance').dag_id:
+        members=""
+    elif "-gcp-" in context.get('task_instance').dag_id:
+        members=""
+    elif "baremetal" in context.get('task_instance').dag_id:
+        members="@mohit @rsevilla @asagtani"
+    elif "chaos" in context.get('task_instance').dag_id:
+        members=""
+    else:
+        members=""
+    return members
+    
+
+
+        
+
+
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    logging.warning(f'slack token = {slack_webhook_token}')
+    #if var_loader.get_git_user() != "cloud-bulldozer":
+    #    print("Task Failed")
+    #    return 
+   
     slack_msg = """
-            :red_circle: Task Failed. 
+            :red_circle: Task Failed {mem} 
             *Task*: {task}  
             *Dag*: {dag} 
             *Execution Time*: {exec_date}  
@@ -14,6 +43,7 @@ def task_fail_slack_alert(context):
             """.format(
             task=context.get('task_instance').task_id,
             dag=context.get('task_instance').dag_id,
+            mem=alert_members(context),
             ti=context.get('task_instance'),
             exec_date=context.get('execution_date'),
             log_url=context.get('task_instance').log_url,
@@ -23,5 +53,6 @@ def task_fail_slack_alert(context):
         http_conn_id='slack',
         webhook_token=slack_webhook_token,
         message=slack_msg,
-        username='airflow')
+        username='airflow',
+        link_names=True)
     return failed_alert.execute(context=context)

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -6,17 +6,17 @@ SLACK_CONN_ID = 'slack'
 
 def alert_members(context):
     if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id:
-        members="@morenod @dry"
+        members=" @morenod @dry"
     elif "aws" in context.get('task_instance').dag_id:
-        members="@mohit @rsevilla @asagtani"
+        members=" @mohit @rsevilla @asagtani"
     elif "openstack" in context.get('task_instance').dag_id:
-        members="@asagtani @masco"
+        members=" @asagtani @masco"
     elif "azure" in context.get('task_instance').dag_id:
-        members=""
+        members=" @mohit @rsevilla @asagtani"
     elif "-gcp-" in context.get('task_instance').dag_id:
-        members=""
+        members=" @mohit @rsevilla @asagtani"
     elif "baremetal" in context.get('task_instance').dag_id:
-        members="@mohit @rsevilla @asagtani"
+        members=" @mohit @rsevilla @asagtani"
     elif "chaos" in context.get('task_instance').dag_id:
         members=""
     else:

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -7,11 +7,16 @@ from openshift_nightlies.util import var_loader
 SLACK_CONN_ID = 'slack'
 
 def alert_members(context):
-    if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id or "-aro-" in context.get('task_instance').dag_id:
-        members=" @perfscale-managed-services-team" 
-    elif "aws" in context.get('task_instance').dag_id or "azure" in context.get('task_instance').dag_id or "-gcp-" in context.get('task_instance').dag_id or "baremetal" in context.get('task_instance').dag_id:
+
+    dag_id = context.get('task_instance').dag_id 
+    managed_services_terms = [ "rosa", "rogcp", "-aro-" ] 
+    perf_core_terms = ["aws", "azure", "-gcp-","baremetal"]
+
+    if any(term in dag_id for term in managed_services_terms):
+        members = " @perfscale-managed-services-team"
+    elif any(term in dag_id for term in perf_core_terms):
         members=" @perfscale-core-team"
-    elif "openstack" in context.get('task_instance').dag_id:
+    elif "openstack" in dag_id:
         members=" @asagtani @masco"
     else:
         members=""

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -18,7 +18,7 @@ def alert_members(context):
     return members    
 
 def get_hyperlink(context):
-    link= '{"blocks":[{"type": "section","text":{"type": "mrkdwn","text": "<{0}|Dag Link>"}}]}'.format(context.get('task_instance').log_url)
+    link= r'{"blocks":[{"type": "section","text":{"type": "mrkdwn","text":'+"<{0}|Dag Link>".format(context.get('task_instance').log_url)+'"}}]}'
     return str(link)        
 
 

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -2,34 +2,30 @@ from airflow.hooks.base import BaseHook
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
 import logging
 from os import environ
+from openshift_nightlies.util import var_loader
 
 SLACK_CONN_ID = 'slack'
-
-# Used to get the git user for the repo the dags live in. 
-def get_git_user():
-    git_repo = environ['GIT_REPO']
-    git_path = git_repo.split("https://github.com/")[1]
-    git_user = git_path.split('/')[0]
-    return git_user.lower()
-
 
 def alert_members(context):
     if "rosa" in context.get('task_instance').dag_id or "rogcp" in context.get('task_instance').dag_id or "-aro-" in context.get('task_instance').dag_id:
         members=" @perfscale-managed-services-team" 
-    elif "aws" in context.get('task_instance').dag_id or "azure" in context.get('task_instance').dag_id or "-gcp-" in context.get('task_instance').dag_id or "baremetal" in context.get('task_instance').dag_id:
+    elif "awsf" in context.get('task_instance').dag_id or "azure" in context.get('task_instance').dag_id or "-gcp-" in context.get('task_instance').dag_id or "baremetal" in context.get('task_instance').dag_id:
         members=" @perfscale-core-team"
     elif "openstack" in context.get('task_instance').dag_id:
         members=" @asagtani @masco"
     else:
         members=""
-    return members            
+    return members    
+
+def get_hyperlink(context):
+    return '{"blocks":[{"type": "section","text":{"type": "mrkdwn","text": "<{0}|Dag Link>"}}]}'.format(context.get('task_instance').log_url)        
 
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    if get_git_user() != "cloud-bulldozer":
-        print("Task Failed")
-        return
+    #if var_loader.get_git_user() != "cloud-bulldozer":
+    #    print("Task Failed")
+    #    return
     if "index" in context.get('task_instance').task_id:
         print("Index Task Failed")
         return
@@ -46,7 +42,7 @@ def task_fail_slack_alert(context):
             mem=alert_members(context),
             ti=context.get('task_instance'),
             exec_date=context.get('execution_date'),
-            log_url=context.get('task_instance').log_url,
+            log_url=get_hyperlink(context),
         )
     failed_alert = SlackWebhookOperator(
         task_id='slack_test',

--- a/dags/openshift_nightlies/util/var_loader.py
+++ b/dags/openshift_nightlies/util/var_loader.py
@@ -1,6 +1,6 @@
 import json
 from os import environ
-from openshift_nightlies.util import constants, executor
+from openshift_nightlies.util import constants
 from openshift_nightlies.models.release import OpenshiftRelease
 
 import requests


### PR DESCRIPTION
### Description
Adds logic to ping specific slack groups for specific dag failures, ignore any index task failures and ignore task failures from any playgrounds(will notify for failures only on the main airflow-ci)

