### PR TITLE
Mark a dag as failed if any upstream tasks fail

### DIFF
--- a/dags/openshift_nightlies/dag.py
+++ b/dags/openshift_nightlies/dag.py
@@ -148,13 +148,14 @@ class OpenstackNightlyDAG(AbstractOpenshiftNightlyDAG):
         installer = self._get_openshift_installer()
         install_cluster = installer.get_install_task()
         connect_to_platform = self._get_platform_connector().get_task()
+        final_status=final_dag_status.get_task(self.dag)
         with TaskGroup("benchmarks", prefix_group_id=False, dag=self.dag) as benchmarks:
             benchmark_tasks = self._get_e2e_benchmarks().get_benchmarks()
             chain(*benchmark_tasks)
 
         if self.config.cleanup_on_success:
             cleanup_cluster = installer.get_cleanup_task()
-            install_cluster >> connect_to_platform >> benchmarks >> cleanup_cluster
+            install_cluster >> connect_to_platform >> benchmarks >> cleanup_cluster >> final_status
         else:
             install_cluster >> connect_to_platform >> benchmarks
 
@@ -167,6 +168,7 @@ class RosaNightlyDAG(AbstractOpenshiftNightlyDAG):
         installer = self._get_openshift_installer()
         install_cluster = installer.get_install_task()
         connect_to_platform = self._get_platform_connector().get_task()
+        final_status=final_dag_status.get_task(self.dag)
         with TaskGroup("benchmarks", prefix_group_id=False, dag=self.dag) as benchmarks:
             benchmark_tasks = self._get_e2e_benchmarks().get_benchmarks()
             chain(*benchmark_tasks)
@@ -175,7 +177,7 @@ class RosaNightlyDAG(AbstractOpenshiftNightlyDAG):
 
         if self.config.cleanup_on_success:
             cleanup_cluster = installer.get_cleanup_task()
-            install_cluster >> rosa_post_installation >> connect_to_platform >> benchmarks >> cleanup_cluster
+            install_cluster >> rosa_post_installation >> connect_to_platform >> benchmarks >> cleanup_cluster >> final_status
         else:
             install_cluster >> rosa_post_installation >> connect_to_platform >> benchmarks
 
@@ -188,6 +190,7 @@ class RoGCPNightlyDAG(AbstractOpenshiftNightlyDAG):
         installer = self._get_openshift_installer()
         install_cluster = installer.get_install_task()
         connect_to_platform = self._get_platform_connector().get_task()
+        final_status=final_dag_status.get_task(self.dag)
         with TaskGroup("benchmarks", prefix_group_id=False, dag=self.dag) as benchmarks:
             benchmark_tasks = self._get_e2e_benchmarks().get_benchmarks()
             chain(*benchmark_tasks)
@@ -195,7 +198,7 @@ class RoGCPNightlyDAG(AbstractOpenshiftNightlyDAG):
 
         if self.config.cleanup_on_success:
             cleanup_cluster = installer.get_cleanup_task()
-            install_cluster >> connect_to_platform >> benchmarks >> cleanup_cluster
+            install_cluster >> connect_to_platform >> benchmarks >> cleanup_cluster >> final_status
         else:
             install_cluster >> connect_to_platform >> benchmarks
 

--- a/dags/openshift_nightlies/dag.py
+++ b/dags/openshift_nightlies/dag.py
@@ -21,7 +21,7 @@ from openshift_nightlies.tasks.install.baremetal import jetski, webfuse
 from openshift_nightlies.tasks.install.rosa import rosa
 from openshift_nightlies.tasks.install.rogcp import rogcp
 from openshift_nightlies.tasks.benchmarks import e2e
-from openshift_nightlies.tasks.utils import rosa_post_install, scale_ci_diagnosis, platform_connector
+from openshift_nightlies.tasks.utils import rosa_post_install, scale_ci_diagnosis, platform_connector,final_dag_status
 from openshift_nightlies.tasks.index import status
 from openshift_nightlies.util import var_loader, manifest, constants
 from abc import ABC, abstractmethod
@@ -89,6 +89,7 @@ class CloudOpenshiftNightlyDAG(AbstractOpenshiftNightlyDAG):
         installer = self._get_openshift_installer()
         install_cluster = installer.get_install_task()
         connect_to_platform = self._get_platform_connector().get_task()
+        final_status=final_dag_status.get_task(self.dag)
 
         with TaskGroup("utils", prefix_group_id=False, dag=self.dag) as utils:
             utils_tasks = self._get_scale_ci_diagnosis().get_utils()
@@ -100,7 +101,7 @@ class CloudOpenshiftNightlyDAG(AbstractOpenshiftNightlyDAG):
 
         if self.config.cleanup_on_success:
             cleanup_cluster = installer.get_cleanup_task()
-            install_cluster >> connect_to_platform >> benchmarks >> utils >> cleanup_cluster
+            install_cluster >> connect_to_platform >> benchmarks >> utils >> cleanup_cluster >> final_status
         else:
             install_cluster >> connect_to_platform >> benchmarks >> utils
 

--- a/dags/openshift_nightlies/tasks/utils/final_dag_status.py
+++ b/dags/openshift_nightlies/tasks/utils/final_dag_status.py
@@ -8,9 +8,15 @@ from airflow.operators.python import PythonOperator
 
 
 def final_status(**kwargs):
+    failed_tasks=[]
     for task_instance in kwargs['dag_run'].get_task_instances():
-        if task_instance.current_state() != 'success' and task_instance.task_id != kwargs['task_instance'].task_id:
-            raise Exception("Task {} failed. Failing this DAG run".format(task_instance.task_id))
+        if "index" in task_instance.task_id:
+            continue
+        elif task_instance.current_state() != 'success' and task_instance.task_id != kwargs['task_instance'].task_id:
+            failed_tasks.append(task_instance.task_id)
+
+    if len(failed_tasks) > 0:
+        raise Exception("Tasks {} failed. Failing this DAG run".format(failed_tasks))
 
 
 

--- a/dags/openshift_nightlies/tasks/utils/final_dag_status.py
+++ b/dags/openshift_nightlies/tasks/utils/final_dag_status.py
@@ -9,7 +9,7 @@ from airflow.operators.python import PythonOperator
 
 def final_status(**kwargs):
     for task_instance in kwargs['dag_run'].get_task_instances():
-        if task_instance.current_state() != State.SUCCESS and task_instance.task_id != kwargs['task_instance'].task_id:
+        if task_instance.current_state() != 'success' and task_instance.task_id != kwargs['task_instance'].task_id:
             raise Exception("Task {} failed. Failing this DAG run".format(task_instance.task_id))
 
 

--- a/dags/openshift_nightlies/tasks/utils/final_dag_status.py
+++ b/dags/openshift_nightlies/tasks/utils/final_dag_status.py
@@ -1,0 +1,24 @@
+from os import environ
+from openshift_nightlies.util import var_loader, executor, constants
+from openshift_nightlies.models.release import OpenshiftRelease
+from openshift_nightlies.models.dag_config import DagConfig
+
+
+from airflow.operators.python import PythonOperator
+
+
+def final_status(**kwargs):
+    for task_instance in kwargs['dag_run'].get_task_instances():
+        if task_instance.current_state() != State.SUCCESS and task_instance.task_id != kwargs['task_instance'].task_id:
+            raise Exception("Task {} failed. Failing this DAG run".format(task_instance.task_id))
+
+
+
+def get_task(dag):
+    return PythonOperator(
+        task_id='final_status',
+        provide_context=True,
+        python_callable=final_status,
+        trigger_rule='all_done',
+        dag=dag,
+    )

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -30,14 +30,13 @@ def get_hyperlink(context):
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     if var_loader.get_git_user() != "cloud-bulldozer":
-        print("Task Failed")
         return
-    if "index" in context.get('task_instance').task_id:
-        print("Index Task Failed")
+    if context.get('task_instance').task_id != "final_status":
+        print(context.get('task_instance').task_id,"Task failed")
         return
    
     slack_msg = """
-            :red_circle: Task Failed {mem} 
+            :red_circle: DAG Failed {mem} 
             *Task*: {task}  
             *Dag*: {dag} 
             *Execution Time*: {exec_date}  

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -29,8 +29,9 @@ def get_hyperlink(context):
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    if var_loader.get_git_user() != "cloud-bulldozer":
-        return
+    #if var_loader.get_git_user() != "cloud-bulldozer":
+    #    print("DAG Failed since one or more upstream tasks failed")
+    #    return
     if context.get('task_instance').task_id != "final_status":
         print(context.get('task_instance').task_id,"Task failed")
         return

--- a/dags/openshift_nightlies/util/slack_integration.py
+++ b/dags/openshift_nightlies/util/slack_integration.py
@@ -29,9 +29,9 @@ def get_hyperlink(context):
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    #if var_loader.get_git_user() != "cloud-bulldozer":
-    #    print("DAG Failed since one or more upstream tasks failed")
-    #    return
+    if var_loader.get_git_user() != "cloud-bulldozer":
+        print("Task Failed")
+        return
     if context.get('task_instance').task_id != "final_status":
         print(context.get('task_instance').task_id,"Task failed")
         return


### PR DESCRIPTION
### Description
Currently a dag is marked fail/success depending on the execution of the last cleanup task only. If any task fails upstream and if the cleanup task succeeds the dag is marked success since airflow only takes the status of the last task into account in a dag.
This PR adds a new last task called final_status which looks at the status of completed tasks and fails if any upstream task has failed, it fails logging the name of the task which failed. it passes only if all upstream tasks have passed successfully.
Eg of dag runs which fail and pass: http://harshith-umesh-faildag-airflow.apps.sailplane.perf.lab.eng.rdu2.redhat.com/tree?dag_id=4.10-aws-ovn-data-plane 