### PR TITLE
Timeout for benchmark tasks

### DIFF
--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -114,7 +114,7 @@ class E2EBenchmarks():
                 dag=self.dag,
                 env=env,
                 do_xcom_push=True,
-                execution_timeout=timedelta(seconds=600),
+                execution_timeout=timedelta(seconds=21600),
                 executor_config=self.exec_config
         )
 

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -114,6 +114,7 @@ class E2EBenchmarks():
                 dag=self.dag,
                 env=env,
                 do_xcom_push=True,
+                execution_timeout=timedelta(seconds=600),
                 executor_config=self.exec_config
         )
 


### PR DESCRIPTION
### Description
Sets a timeout of 6 hours for each benchmark task, so as to kill any hung benchmark tasks. This is required since some tasks fail to exit/terminate and run for very long periods of time(25-48 hours) preventing the dag execution to move forward.
