### PR TITLE
Fix unified kube-burner env vars

### DIFF
--- a/dags/openshift_nightlies/config/baremetal-benchmarks/webfuse-bench.json
+++ b/dags/openshift_nightlies/config/baremetal-benchmarks/webfuse-bench.json
@@ -15,8 +15,9 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=node-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "node-density",
                 "PODS_PER_NODE": "250",
                 "NODE_COUNT": "27",
                 "JOB_TIMEOUT": "18000",
@@ -33,8 +34,9 @@
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "500",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",

--- a/dags/openshift_nightlies/config/benchmarks/acs.json
+++ b/dags/openshift_nightlies/config/benchmarks/acs.json
@@ -18,8 +18,9 @@
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "500",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",
@@ -37,8 +38,9 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=node-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "node-density",
                 "PODS_PER_NODE": "250",
                 "NODE_COUNT": "25",
                 "JOB_TIMEOUT": "18000",
@@ -67,8 +69,9 @@
         {
             "name": "cluster-density-50",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "1000",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",
@@ -136,8 +139,9 @@
         {
             "name": "load-cluster-preupgrade",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "500",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",

--- a/dags/openshift_nightlies/config/benchmarks/control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/control-plane.json
@@ -8,8 +8,9 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=node-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "node-density",
                 "PODS_PER_NODE": "250",
                 "NODE_COUNT": "27",
                 "JOB_TIMEOUT": "18000",
@@ -26,8 +27,9 @@
         {
             "name": "node-density-heavy",
             "workload": "kube-burner",
-            "command": "WORKLOAD=node-density-heavy ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "node-density-heavy",
                 "PODS_PER_NODE": "250",
                 "NODE_COUNT": "27",
                 "JOB_TIMEOUT": "18000",
@@ -44,8 +46,9 @@
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "500",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",
@@ -61,8 +64,9 @@
         {
             "name": "load-cluster-preupgrade",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh", 
+            "command": "./run.sh", 
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "500",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",

--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane.json
@@ -8,8 +8,9 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=node-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "node-density",
                 "PODS_PER_NODE": "250",
                 "NODE_COUNT": "24",
                 "JOB_TIMEOUT": "18000",
@@ -26,8 +27,9 @@
         {
             "name": "node-density-heavy",
             "workload": "kube-burner",
-            "command": "WORKLOAD=node-density-heavy ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "node-density-heavy",
                 "PODS_PER_NODE": "250",
                 "NODE_COUNT": "24",
                 "JOB_TIMEOUT": "18000",
@@ -44,8 +46,9 @@
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "500",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
@@ -8,8 +8,9 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=node-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "node-density",
                 "PODS_PER_NODE": "250",
                 "NODE_COUNT": "250",
                 "JOB_TIMEOUT": "18000",
@@ -26,8 +27,9 @@
         {
             "name": "node-density-heavy",
             "workload": "kube-burner",
-            "command": "WORKLOAD=node-density-heavy ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "node-density-heavy",
                 "PODS_PER_NODE": "100",
                 "NODE_COUNT": "250",
                 "JOB_TIMEOUT": "18000",
@@ -44,8 +46,9 @@
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "4000",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "2m",
@@ -61,8 +64,9 @@
         {
             "name": "load_cluster_preupgrade",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "4000",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "2m",

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
@@ -8,8 +8,9 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=node-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "node-density",
                 "PODS_PER_NODE": "250",
                 "NODE_COUNT": "120",
                 "JOB_TIMEOUT": "18000",
@@ -26,8 +27,9 @@
         {
             "name": "node-density-heavy",
             "workload": "kube-burner",
-            "command": "WORKLOAD=node-density-heavy ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "node-density-heavy",
                 "PODS_PER_NODE": "100",
                 "NODE_COUNT": "120",
                 "JOB_TIMEOUT": "18000",
@@ -44,8 +46,9 @@
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "1000",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",
@@ -61,8 +64,9 @@
         {
             "name": "load-cluster-preupgrade",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "1000",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",

--- a/dags/openshift_nightlies/config/benchmarks/openstack.json
+++ b/dags/openshift_nightlies/config/benchmarks/openstack.json
@@ -18,8 +18,9 @@
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "300",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",
@@ -34,8 +35,9 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "command": "WORKLOAD=node-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "node-density",
                 "PODS_PER_NODE": "250",
                 "NODE_COUNT": "25",
                 "JOB_TIMEOUT": "18000",
@@ -61,8 +63,9 @@
         {
             "name": "cluster-density-50",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "700",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",
@@ -132,8 +135,9 @@
         {
             "name": "load_cluster_preupgrade",
             "workload": "kube-burner",
-            "command": "WORKLOAD=cluster-density ./run.sh",
+            "command": "./run.sh",
             "env": {
+                "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "300",
                 "JOB_TIMEOUT": "18000",
                 "STEP_SIZE": "30s",


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
Fix unified kube-burner env vars. run_benchmark.sh does not work with notations like `WORKLOAD=node-density ./run.sh",`

### Fixes
