### PR TITLE
Disable task retry in benchmarks

### DIFF
--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -110,7 +110,7 @@ class E2EBenchmarks():
                 task_id=f"{task_prefix if self.task_group != 'benchmarks' else ''}{benchmark['name']}",
                 depends_on_past=False,
                 bash_command=f"{constants.root_dag_dir}/scripts/run_benchmark.sh -w {benchmark['workload']} -c {benchmark['command']} ",
-                retries=3,
+                retries=0,
                 dag=self.dag,
                 env=env,
                 do_xcom_push=True,


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

We shouldn't retry failed benchmarks.

### Fixes
