### PR TITLE
Remove 4.9 rosa, maanged services gcp and hypershift dags

### DIFF
--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -99,7 +99,7 @@ platforms:
 
 # Do not program concurrent builds of ROSA/ROGCP/ARO
   rosa:
-    versions: [4.9, "4.10", 4.11]
+    versions: ["4.10", 4.11]
     variants:
       - name: sdn-control-plane
         schedule:  "0 12 * * 1,3,5"
@@ -122,7 +122,7 @@ platforms:
           install: rosa/ovn.json
           benchmarks: data-plane.json
   rogcp:
-    versions: [4.9, "4.10", 4.11]
+    versions: ["4.10", 4.11]
     variants:
       - name: sdn-control-plane
         schedule:  "20 12 * * 1,3,5"
@@ -136,7 +136,7 @@ platforms:
           benchmarks: data-plane.json
 
   hypershift:
-    versions: [4.9, "4.10", 4.11]
+    versions: ["4.10", 4.11]
     variants:
       - name: sdn-control-plane
         schedule:  "0 12 * * 1,3,5"


### PR DESCRIPTION
4.10 is already the default version. removing older versions from rosa, gcp managed services and hypershift
