### PR TITLE
Custom trigger rule

### DIFF
--- a/dags/openshift_nightlies/config/benchmarks/control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/control-plane.json
@@ -27,6 +27,7 @@
         {
             "name": "node-density-heavy",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "node-density-heavy",
@@ -46,6 +47,7 @@
         {
             "name": "cluster-density",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "cluster-density",
@@ -64,6 +66,7 @@
         {
             "name": "load-cluster-preupgrade",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh", 
             "env": {
                 "WORKLOAD": "cluster-density",
@@ -81,6 +84,7 @@
         {
             "name": "upgrades",
             "workload": "upgrade-perf",
+            "trigger_rule": "all_done",
             "command": "./run_upgrade_fromgit.sh",
             "env": {
                 "LATEST": "true",

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
@@ -27,6 +27,7 @@
         {
             "name": "node-density-heavy",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "node-density-heavy",
@@ -46,6 +47,7 @@
         {
             "name": "cluster-density",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "cluster-density",
@@ -64,6 +66,7 @@
         {
             "name": "load_cluster_preupgrade",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "cluster-density",
@@ -81,6 +84,7 @@
         {
             "name": "upgrades",
             "workload": "upgrade-perf",
+            "trigger_rule": "all_done",
             "command": "./run_upgrade_fromgit.sh",
             "env": {
                 "LATEST": "true",

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
@@ -27,6 +27,7 @@
         {
             "name": "node-density-heavy",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "node-density-heavy",
@@ -46,6 +47,7 @@
         {
             "name": "cluster-density",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "cluster-density",
@@ -64,6 +66,7 @@
         {
             "name": "load-cluster-preupgrade",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "cluster-density",
@@ -81,6 +84,7 @@
         {
             "name": "upgrades",
             "workload": "upgrade-perf",
+            "trigger_rule": "all_done",
             "command": "./run_upgrade_fromgit.sh",
             "env": {
                 "LATEST": "true",

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -111,6 +111,7 @@ class E2EBenchmarks():
                 depends_on_past=False,
                 bash_command=f"{constants.root_dag_dir}/scripts/run_benchmark.sh -w {benchmark['workload']} -c {benchmark['command']} ",
                 retries=0,
+                trigger_rule=benchmark.get("trigger_rule", "all_success"),
                 dag=self.dag,
                 env=env,
                 do_xcom_push=True,

--- a/dags/openshift_nightlies/tasks/utils/final_dag_status.py
+++ b/dags/openshift_nightlies/tasks/utils/final_dag_status.py
@@ -26,5 +26,6 @@ def get_task(dag):
         provide_context=True,
         python_callable=final_status,
         trigger_rule='all_done',
+        retries=0,
         dag=dag,
     )


### PR DESCRIPTION
### Description

Permit setting custom trigger rules from the benchmark config file so we can move forward to the next task when the current task fails:

According to airflow documentation we can set these trigger rules:

```
    all_success: (default) all parents have succeeded
    all_failed: all parents are in a failed or upstream_failed state
    all_done: all parents are done with their execution
    one_failed: fires as soon as at least one parent has failed, it does not wait for all parents to be done
    one_success: fires as soon as at least one parent succeeds, it does not wait for all parents to be done
    none_failed: all parents have not failed (failed or upstream_failed) i.e. all parents have succeeded or been skipped
    none_skipped: no parent is in a skipped state, i.e. all parents are in a success, failed, or upstream_failed state
    dummy: dependencies are just for show, trigger at will
```

Also modified the control plane perfscale pipelines so that node-density expects the installation to be successful before being triggered  (all_success) and the subsequent tasks wait for its parents to be finished (all_done)

The final_status dag will work the same way as it used, and will report the failing tasks only.

----

Example where node-density failed and the subsequent tasks were executed regardless of this failure and final_status is reporting a failure in the dag:

![image](https://user-images.githubusercontent.com/4614641/159444007-c82a742c-726b-47ea-95f0-9dce8c600b86.png)

