### PR TITLE
Place grafana-agent preferably on an infra node

### DIFF
--- a/dags/openshift_nightlies/scripts/utils/templates/grafana-agent.yaml
+++ b/dags/openshift_nightlies/scripts/utils/templates/grafana-agent.yaml
@@ -63,6 +63,14 @@ spec:
       labels:
         name: grafana-agent
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
       containers:
       - args:
         - --config.file=/etc/agent/agent.yaml


### PR DESCRIPTION
Closes: https://github.com/cloud-bulldozer/airflow-kubernetes/issues/144

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>
