### PR TITLE
updated benchmarks for hypeshift

### DIFF
--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane.json
@@ -3,7 +3,12 @@
         {
             "name": "baseline",
             "workload": "baseline-performance",
-            "command": "./baseline_perf.sh"            
+            "command": "./baseline_perf.sh",
+            "env": {
+                "STEP_SIZE": "60s",
+                "HYPERSHIFT": "true",
+                "METRICS_PROFILE": "metrics-profiles/hypershift-metrics.yaml"
+            }       
         },      
         {
             "name": "node-density",
@@ -16,7 +21,9 @@
                 "JOB_TIMEOUT": "18000",
                 "QPS": "20",
                 "BURST": "20",
-                "STEP_SIZE": "30s",
+                "STEP_SIZE": "60s",
+                "HYPERSHIFT": "true",
+                "METRICS_PROFILE": "metrics-profiles/hypershift-metrics.yaml",
                 "LOG_LEVEL": "info",
                 "LOG_STREAMING": "true",
                 "CLEANUP_WHEN_FINISH": "true",
@@ -35,7 +42,9 @@
                 "JOB_TIMEOUT": "18000",
                 "QPS": "20",
                 "BURST": "20",
-                "STEP_SIZE": "30s",
+                "STEP_SIZE": "60s",
+                "HYPERSHIFT": "true",
+                "METRICS_PROFILE": "metrics-profiles/hypershift-metrics.yaml",
                 "LOG_LEVEL": "info",
                 "LOG_STREAMING": "true",
                 "CLEANUP_WHEN_FINISH": "true",
@@ -51,7 +60,9 @@
                 "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "500",
                 "JOB_TIMEOUT": "18000",
-                "STEP_SIZE": "30s",
+                "STEP_SIZE": "60s",
+                "HYPERSHIFT": "true",
+                "METRICS_PROFILE": "metrics-profiles/hypershift-metrics.yaml",
                 "QPS": "20",
                 "BURST": "20",
                 "LOG_LEVEL": "info",

--- a/dags/openshift_nightlies/scripts/install/hypershift.sh
+++ b/dags/openshift_nightlies/scripts/install/hypershift.sh
@@ -39,7 +39,7 @@ setup(){
     export ROSA_ENVIRONMENT=$(cat ${json_file} | jq -r .rosa_environment)
     export ROSA_TOKEN=$(cat ${json_file} | jq -r .rosa_token_${ROSA_ENVIRONMENT})
     export MGMT_CLUSTER_NAME=$(cat ${json_file} | jq -r .openshift_cluster_name)
-    export HOSTED_CLUSTER_NAME=$MGMT_CLUSTER_NAME-$HOSTED_NAME
+    export HOSTED_CLUSTER_NAME=hypershift-$MGMT_CLUSTER_NAME-$HOSTED_NAME
     export HOSTED_KUBECONFIG_NAME=$(echo $KUBECONFIG_NAME | awk -F-kubeconfig '{print$1}')-$HOSTED_NAME-kubeconfig
     export HOSTED_KUBEADMIN_NAME=$(echo $KUBEADMIN_NAME | awk -F-kubeadmin '{print$1}')-$HOSTED_NAME-kubeadmin    
     export KUBECONFIG=/home/airflow/auth/config
@@ -89,7 +89,7 @@ create_cluster(){
     export REPLICA_TYPE=$(cat ${json_file} | jq -r .hosted_control_plane_availability)   
     BASEDOMAIN=$(_get_base_domain $(_get_cluster_id ${MGMT_CLUSTER_NAME}))
     echo $PULL_SECRET > pull-secret
-    hypershift create cluster aws --name $HOSTED_CLUSTER_NAME --node-pool-replicas=$COMPUTE_WORKERS_NUMBER --base-domain $BASEDOMAIN --pull-secret pull-secret --aws-creds aws_credentials --region $AWS_REGION --control-plane-availability-policy $REPLICA_TYPE --network-type $NETWORK_TYPE --instance-type $COMPUTE_WORKERS_TYPE
+    hypershift create cluster aws --name $HOSTED_CLUSTER_NAME --node-pool-replicas=$COMPUTE_WORKERS_NUMBER --base-domain $BASEDOMAIN --pull-secret pull-secret --aws-creds aws_credentials --region $AWS_REGION --control-plane-availability-policy $REPLICA_TYPE --network-type $NETWORK_TYPE --instance-type $COMPUTE_WORKERS_TYPE # --control-plane-operator-image=quay.io/hypershift/hypershift:latest
     echo "Wait till hosted cluster got created and in progress.."
     kubectl wait --for=condition=available=false --timeout=60s hostedcluster -n clusters $HOSTED_CLUSTER_NAME
     kubectl get hostedcluster -n clusters $HOSTED_CLUSTER_NAME

--- a/dags/openshift_nightlies/scripts/install/hypershift.sh
+++ b/dags/openshift_nightlies/scripts/install/hypershift.sh
@@ -89,7 +89,7 @@ create_cluster(){
     export REPLICA_TYPE=$(cat ${json_file} | jq -r .hosted_control_plane_availability)   
     BASEDOMAIN=$(_get_base_domain $(_get_cluster_id ${MGMT_CLUSTER_NAME}))
     echo $PULL_SECRET > pull-secret
-    hypershift create cluster aws --name $HOSTED_CLUSTER_NAME --node-pool-replicas=$COMPUTE_WORKERS_NUMBER --base-domain $BASEDOMAIN --pull-secret pull-secret --aws-creds aws_credentials --region $AWS_REGION --control-plane-availability-policy $REPLICA_TYPE --network-type $NETWORK_TYPE --instance-type $COMPUTE_WORKERS_TYPE # --control-plane-operator-image=quay.io/hypershift/hypershift:latest
+    hypershift create cluster aws --name $HOSTED_CLUSTER_NAME --node-pool-replicas=$COMPUTE_WORKERS_NUMBER --base-domain $BASEDOMAIN --pull-secret pull-secret --aws-creds aws_credentials --region $AWS_REGION --control-plane-availability-policy $REPLICA_TYPE --network-type $NETWORK_TYPE --instance-type $COMPUTE_WORKERS_TYPE
     echo "Wait till hosted cluster got created and in progress.."
     kubectl wait --for=condition=available=false --timeout=60s hostedcluster -n clusters $HOSTED_CLUSTER_NAME
     kubectl get hostedcluster -n clusters $HOSTED_CLUSTER_NAME

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -76,6 +76,14 @@ class E2EBenchmarks():
                 "AWS_DEFAULT_REGION": self.aws_creds['aws_region_for_openshift']
             }
     
+        if self.release.platform == "hypershift":
+            mgmt_cluster_name = release._generate_cluster_name()
+            self.env = {
+                "THANOS_RECEIVER_URL": var_loader.get_secret("thanos_receiver_url"),
+                "PROM_URL": var_loader.get_secret("thanos_querier_url"),
+                "MGMT_CLUSTER_NAME": f"{mgmt_cluster_name}.*",
+                "HOSTED_CLUSTER_NS": f"clusters-hypershift-{mgmt_cluster_name}-{self.task_group}"
+            }
 
     def get_benchmarks(self):
         benchmarks = self._get_benchmarks(self.vars["benchmarks"])

--- a/scripts/playground/cleanup.sh
+++ b/scripts/playground/cleanup.sh
@@ -3,7 +3,7 @@ set -a
 usage() { echo "Usage: $0 [-p <string> (airflow password)]" 1>&2; exit 1; }
 GIT_ROOT=$(git rev-parse --show-toplevel)
 source $GIT_ROOT/scripts/common.sh
-_airflow_namespace=$_remote_user-$_branch-airflow
+_airflow_namespace=$_remote_user-$_branch_display_name-airflow
 
 
 


### PR DESCRIPTION
### Description
Updated benchmarks for hypershift to adopt [new](https://github.com/cloud-bulldozer/e2e-benchmarking/pull/335) templates

[kube-burner report
](http://grafana.apps.observability.perfscale.devcluster.openshift.com/d/n8_lX3-nk/kube-burner-report-v2?orgId=1&from=1649169444793&to=1649170072278&var-Datasource=Observability%20-%20ripsaw-kube-burner&var-sdn=openshift-sdn&var-sdn=openshift-ovn-kubernetes&var-job=baseline-performance-workload&var-job=node-density&var-job=node-density-heavy&var-uuid=48581a0f-hosted-2-node-density-20220405&var-master=&var-worker=ip-10-0-129-121.us-west-2.compute.internal&var-worker=ip-10-0-129-209.us-west-2.compute.internal&var-infra=&var-namespace=All&var-latencyPercentile=P99)

### Fixes #159 
