### PR TITLE
Quote env vars value

### DIFF
--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -51,9 +51,9 @@ run_baremetal_benchmark(){
 
     export KUBECONFIG=/home/kni/clusterconfigs/auth/kubeconfig
     export BENCHMARK=${TASK_GROUP}
-    while read line; do export \$line; done < /tmp/environment_new.txt
-    # clean up the temporary environment file
-    rm -rf /tmp/environment_new.txt
+    cat /tmp/environment_new.txt | awk -v x="'" -F "=" '{print "export " \$1"="x\$2x}' > vars.sh
+    source vars.sh
+    rm -rf /tmp/environment_new.txt vars.sh
     rm -rf /home/kni/ci_${TASK_GROUP}_workspace
     mkdir /home/kni/ci_${TASK_GROUP}_workspace
     pushd /home/kni/ci_${TASK_GROUP}_workspace


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
With the current implementation, the environment variables with with spaces in their value fail when they are exported. We have to double quote the value as shown in the example below.

```shell
rsevilla@wonderland /tmp $ cat environment_new.txt 
FOO=BAR
SELECTOR=TEST 1
rsevilla@wonderland /tmp $ while read line; do export $line; done < /tmp/environment_new.txt
-bash: export: `1': not a valid identifier
```

```shell
rsevilla@wonderland /tmp $ cat /tmp/environment_new.txt | awk -v x="'" -F "=" '{print "export " $1"="x$2x}'
export FOO='BAR'
export SELECTOR='TEST 1'

```



