### PR TITLE
Remove some tasks and version 4.9

### DIFF
--- a/dags/openshift_nightlies/config/benchmarks/control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/control-plane.json
@@ -1,11 +1,6 @@
 {
     "benchmarks": [
         {
-            "name": "baseline",
-            "workload": "baseline-performance",
-            "command": "./baseline_perf.sh"            
-        },      
-        {
             "name": "node-density",
             "workload": "kube-burner",
             "command": "./run.sh",
@@ -61,36 +56,6 @@
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
                 "MUST_GATHER_EACH_TASK": "true"
-            }
-        },
-        {
-            "name": "load-cluster-preupgrade",
-            "workload": "kube-burner",
-            "trigger_rule": "all_done",
-            "command": "./run.sh", 
-            "env": {
-                "WORKLOAD": "cluster-density",
-                "JOB_ITERATIONS": "500",
-                "JOB_TIMEOUT": "18000",
-                "STEP_SIZE": "30s",
-                "QPS": "20",
-                "BURST": "20",
-                "LOG_LEVEL": "info",
-                "LOG_STREAMING": "true",
-                "CLEANUP_WHEN_FINISH": "false",
-                "CLEANUP": "true"
-            }
-        },
-        {
-            "name": "upgrades",
-            "workload": "upgrade-perf",
-            "trigger_rule": "all_done",
-            "command": "./run_upgrade_fromgit.sh",
-            "env": {
-                "LATEST": "true",
-                "CHANNEL": "nightlies",
-                "TIMEOUT": "400",
-                "POLL_INTERVAL": "10"
             }
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
@@ -1,6 +1,14 @@
 {
     "benchmarks": [
         {
+            "name": "baseline",
+            "workload": "baseline-performance",
+            "command": "./baseline_perf.sh",
+            "env": {
+                "WATCH_TIME": "15"
+            }
+        },
+        {
             "name": "node-density",
             "workload": "kube-burner",
             "command": "./run.sh",
@@ -16,7 +24,8 @@
                 "LOG_STREAMING": "true",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true"
+                "MUST_GATHER_EACH_TASK": "true",
+                "CLEANUP_TIMEOUT": "1h"
             }
         },
         {
@@ -36,7 +45,8 @@
                 "LOG_STREAMING": "true",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true"
+                "MUST_GATHER_EACH_TASK": "true",
+                "CLEANUP_TIMEOUT": "1h"
             }
         },
         {
@@ -55,7 +65,8 @@
                 "LOG_STREAMING": "true",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true"
+                "MUST_GATHER_EACH_TASK": "true",
+                "CLEANUP_TIMEOUT": "1h"
             }
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
@@ -1,11 +1,6 @@
 {
     "benchmarks": [
         {
-            "name": "baseline",
-            "workload": "baseline-performance",
-            "command": "./baseline_perf.sh"            
-        },      
-        {
             "name": "node-density",
             "workload": "kube-burner",
             "command": "./run.sh",
@@ -61,36 +56,6 @@
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
                 "MUST_GATHER_EACH_TASK": "true"
-            }
-        },
-        {
-            "name": "load_cluster_preupgrade",
-            "workload": "kube-burner",
-            "trigger_rule": "all_done",
-            "command": "./run.sh",
-            "env": {
-                "WORKLOAD": "cluster-density",
-                "JOB_ITERATIONS": "4000",
-                "JOB_TIMEOUT": "18000",
-                "STEP_SIZE": "2m",
-                "QPS": "20",
-                "BURST": "20",
-                "LOG_LEVEL": "info",
-                "LOG_STREAMING": "true",
-                "CLEANUP_WHEN_FINISH": "false",
-                "CLEANUP": "true"
-            }
-        },
-        {
-            "name": "upgrades",
-            "workload": "upgrade-perf",
-            "trigger_rule": "all_done",
-            "command": "./run_upgrade_fromgit.sh",
-            "env": {
-                "LATEST": "true",
-                "CHANNEL": "nightlies",
-                "TIMEOUT": "400",
-                "POLL_INTERVAL": "10"
             }
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
@@ -1,11 +1,6 @@
 {
     "benchmarks": [
         {
-            "name": "baseline",
-            "workload": "baseline-performance",
-            "command": "./baseline_perf.sh"            
-        },      
-        {
             "name": "node-density",
             "workload": "kube-burner",
             "command": "./run.sh",
@@ -61,36 +56,6 @@
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
                 "MUST_GATHER_EACH_TASK": "true"
-            }
-        },
-        {
-            "name": "load-cluster-preupgrade",
-            "workload": "kube-burner",
-            "trigger_rule": "all_done",
-            "command": "./run.sh",
-            "env": {
-                "WORKLOAD": "cluster-density",
-                "JOB_ITERATIONS": "1000",
-                "JOB_TIMEOUT": "18000",
-                "STEP_SIZE": "30s",
-                "QPS": "20",
-                "BURST": "20",
-                "LOG_LEVEL": "info",
-                "LOG_STREAMING": "true",
-                "CLEANUP_WHEN_FINISH": "false",
-                "CLEANUP": "true"
-            }
-        },
-        {
-            "name": "upgrades",
-            "workload": "upgrade-perf",
-            "trigger_rule": "all_done",
-            "command": "./run_upgrade_fromgit.sh",
-            "env": {
-                "LATEST": "true",
-                "CHANNEL": "nightlies",
-                "TIMEOUT": "400",
-                "POLL_INTERVAL": "10"
             }
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
@@ -1,6 +1,14 @@
 {
     "benchmarks": [
         {
+            "name": "baseline",
+            "workload": "baseline-performance",
+            "command": "./baseline_perf.sh",
+            "env": {
+                "WATCH_TIME": "15"
+            }
+        },
+        {
             "name": "node-density",
             "workload": "kube-burner",
             "command": "./run.sh",
@@ -11,12 +19,13 @@
                 "JOB_TIMEOUT": "18000",
                 "QPS": "20",
                 "BURST": "20",
-                "STEP_SIZE": "30s",
+                "STEP_SIZE": "2m",
                 "LOG_LEVEL": "info",
                 "LOG_STREAMING": "true",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true"
+                "MUST_GATHER_EACH_TASK": "true",
+				"CLEANUP_TIMEOUT": "1h"
             }
         },
         {
@@ -31,12 +40,13 @@
                 "JOB_TIMEOUT": "18000",
                 "QPS": "20",
                 "BURST": "20",
-                "STEP_SIZE": "30s",
+                "STEP_SIZE": "2m",
                 "LOG_LEVEL": "info",
                 "LOG_STREAMING": "true",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true"
+                "MUST_GATHER_EACH_TASK": "true",
+                "CLEANUP_TIMEOUT": "1h"
             }
         },
         {
@@ -48,14 +58,15 @@
                 "WORKLOAD": "cluster-density",
                 "JOB_ITERATIONS": "1000",
                 "JOB_TIMEOUT": "18000",
-                "STEP_SIZE": "30s",
+                "STEP_SIZE": "2m",
                 "QPS": "20",
                 "BURST": "20",
                 "LOG_LEVEL": "info",
                 "LOG_STREAMING": "true",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true"
+                "MUST_GATHER_EACH_TASK": "true",
+                "CLEANUP_TIMEOUT": "1h"
             }
         }
     ]

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -28,7 +28,7 @@ dagConfig:
 
 platforms:
   cloud:
-    versions: [4.9, "4.10", 4.11]
+    versions: ["4.10", 4.11]
     providers: ["aws", "gcp", "azure"]
     variants: 
     - name: sdn-control-plane

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -1,14 +1,14 @@
 versions:
 - version: 4.9
-  alias: stable
+  alias: previous
   releaseStream: 4.9.0-0.nightly
   baremetalReleaseStream: latest-4.9
 - version: "4.10"
-  alias: next
+  alias: stable
   releaseStream: 4.10.0-0.nightly
   baremetalReleaseStream: latest-4.10
 - version: 4.11
-  alias: future
+  alias: next
   releaseStream: 4.11.0-0.nightly
   baremetalReleaseStream: latest-4.11
 


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Let's speed up our pipelines by removing some tasks:

- baseline-performance: It's not worth to having this task. It's adding an extra 30 minutes delay and the value it provides is not very clear
- load_cluster_preupgrade and upgrades: These tasks don't work as they are expected, since the upgrade task tries to update to the latest version available, and the pipeline deploys the latest version available, for that reason, no upgrade is actually performed as shown in the log below:
```
[2022-04-07, 08:11:57 UTC] {subprocess.py:89} INFO - 2022-04-07T08:11:57Z - INFO     - MainProcess - py_es_bulk: Using streaming bulk indexer
[2022-04-07, 08:11:57 UTC] {subprocess.py:89} INFO - 2022-04-07T08:11:57Z - INFO     - MainProcess - wrapper_factory: identified upgrade as the benchmark wrapper
[2022-04-07, 08:12:04 UTC] {subprocess.py:89} INFO - 2022-04-07T08:12:04Z - INFO     - MainProcess - trigger_upgrade: Upgrading cluster mycluster to version 4.11.0-0.nightly-2022-04-01-172551 with uuid f78d7dd4-upgrades-20220407
[2022-04-07, 08:12:04 UTC] {subprocess.py:89} INFO - 2022-04-07T08:12:04Z - INFO     - MainProcess - trigger_upgrade: Current cluster version is: 4.11.0-0.nightly-2022-04-01-172551
[2022-04-07, 08:12:04 UTC] {subprocess.py:89} INFO - 2022-04-07T08:12:04Z - INFO     - MainProcess - trigger_upgrade: oc adm upgrade --to-latest=true --allow-upgrade-with-warnings=true --force=true
```

We have to rethink how we do this