### PR TITLE
Add rosa profiles for installing using AWS ccs authentication

### DIFF
--- a/dags/openshift_nightlies/config/install/rosa/ccs-ovn.json
+++ b/dags/openshift_nightlies/config/install/rosa/ccs-ovn.json
@@ -1,0 +1,14 @@
+{
+    "aws_profile": "",
+    "aws_access_key_id": "",
+    "aws_secret_access_key": "",
+    "aws_authentication_method": "ccs",
+    "rosa_environment": "staging",
+    "rosa_cli_version": "master",
+    "ocm_environment": "stage",
+    "openshift_worker_count": 27,
+    "openshift_network_type": "OVNKubernetes",
+    "openshift_worker_instance_type": "m5.2xlarge",
+    "machineset_metadata_label_prefix": "machine.openshift.io",
+    "openshift_workload_node_instance_type": "m5.2xlarge"
+ }

--- a/dags/openshift_nightlies/config/install/rosa/ccs-sdn.json
+++ b/dags/openshift_nightlies/config/install/rosa/ccs-sdn.json
@@ -1,0 +1,14 @@
+{
+    "aws_profile": "",
+    "aws_access_key_id": "",
+    "aws_secret_access_key": "",
+    "aws_authentication_method": "ccs",
+    "rosa_environment": "staging",
+    "rosa_cli_version": "master",
+    "ocm_environment": "stage",
+    "openshift_worker_count": 27,
+    "openshift_network_type": "OpenShiftSDN",
+    "openshift_worker_instance_type": "m5.2xlarge",
+    "machineset_metadata_label_prefix": "machine.openshift.io",
+    "openshift_workload_node_instance_type": "m5.2xlarge"
+}

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -101,36 +101,48 @@ platforms:
   rosa:
     versions: ["4.10", 4.11]
     variants:
-      - name: sdn-control-plane
+      - name: sts-sdn-control-plane
         schedule:  "0 12 * * 1,3,5"
         config:
           install: rosa/sdn.json
           benchmarks: control-plane.json
-      - name: sdn-data-plane
+      - name: sts-sdn-data-plane
         schedule: "5 12 * * 1"
         config:
           install: rosa/sdn.json
           benchmarks: data-plane.json
-      - name: ovn-control-plane
+      - name: sts-ovn-control-plane
         schedule:  "10 12 * * 1,3,5"
         config:
           install: rosa/ovn.json
           benchmarks: control-plane.json
-      - name: ovn-data-plane
+      - name: sts-ovn-data-plane
         schedule: "15 12 * * 1"
         config:
           install: rosa/ovn.json
           benchmarks: data-plane.json
+      - name: ccs-ovn-control-plane
+        schedule:  "20 12 * * 1,3,5"
+        config:
+          install: rosa/ccs-ovn.json
+          benchmarks: control-plane.json
+      - name: ccs-sdn-control-plane
+        schedule:  "25 12 * * 1,3,5"
+        config:
+          install: rosa/ccs-sdn.json
+          benchmarks: control-plane.json
+
+
   rogcp:
     versions: ["4.10", 4.11]
     variants:
       - name: sdn-control-plane
-        schedule:  "20 12 * * 1,3,5"
+        schedule:  "00 13 * * 1,3,5"
         config:
           install: rogcp/sdn.json
           benchmarks: control-plane.json
       - name: sdn-data-plane
-        schedule: "25 12 * * 1"
+        schedule: "05 13 * * 1"
         config:
           install: rogcp/sdn.json
           benchmarks: data-plane.json


### PR DESCRIPTION
As we are using STS as default AWS authentication method on ROSA installations, we need to add profiles using CCS for comparing installation timings
