### PR TITLE
Removing kubeconfig on indexing cleanup for rosa

### DIFF
--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -170,8 +170,10 @@ postinstall(){
 }
 
 index_metadata(){
-    _download_kubeconfig $(_get_cluster_id ${CLUSTER_NAME}) ./kubeconfig
-    export KUBECONFIG=./kubeconfig
+    if [[ ! "${INDEXDATA[*]}" =~ "cleanup" ]] ; then
+        _download_kubeconfig $(_get_cluster_id ${CLUSTER_NAME}) ./kubeconfig
+        export KUBECONFIG=./kubeconfig
+    fi
     METADATA=$(cat << EOF
 {
 "uuid" : "${UUID}",


### PR DESCRIPTION
Cleanup indexing is executed when cluster is already deleted, so no kubeconfig is available to download