### PR TITLE
Reducing frequency of managed services testing and stopping the non-sts rosa tests

### DIFF
--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -102,7 +102,7 @@ platforms:
     versions: ["4.10", 4.11]
     variants:
       - name: sts-sdn-control-plane
-        schedule:  "0 12 * * 1,3,5"
+        schedule:  "0 12 * * 3"
         config:
           install: rosa/sdn.json
           benchmarks: control-plane.json
@@ -112,7 +112,7 @@ platforms:
           install: rosa/sdn.json
           benchmarks: data-plane.json
       - name: sts-ovn-control-plane
-        schedule:  "10 12 * * 1,3,5"
+        schedule:  "10 12 * * 3"
         config:
           install: rosa/ovn.json
           benchmarks: control-plane.json
@@ -122,12 +122,10 @@ platforms:
           install: rosa/ovn.json
           benchmarks: data-plane.json
       - name: ccs-ovn-control-plane
-        schedule:  "20 12 * * 1,3,5"
         config:
           install: rosa/ccs-ovn.json
           benchmarks: control-plane.json
       - name: ccs-sdn-control-plane
-        schedule:  "25 12 * * 1,3,5"
         config:
           install: rosa/ccs-sdn.json
           benchmarks: control-plane.json
@@ -137,7 +135,7 @@ platforms:
     versions: ["4.10", 4.11]
     variants:
       - name: sdn-control-plane
-        schedule:  "00 13 * * 1,3,5"
+        schedule:  "00 13 * * 3"
         config:
           install: rogcp/sdn.json
           benchmarks: control-plane.json


### PR DESCRIPTION
### Description
Given our current utilization of the resultant data of the managed services runs, I've reduced the frequency of the tests to once a week for each and disabled the non-sts rosa tests


### Fixes
