### PR TITLE
Update airflow container images to 2.3.0

### DIFF
--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -170,8 +170,10 @@ postinstall(){
 }
 
 index_metadata(){
-    _download_kubeconfig $(_get_cluster_id ${CLUSTER_NAME}) ./kubeconfig
-    export KUBECONFIG=./kubeconfig
+    if [[ ! "${INDEXDATA[*]}" =~ "cleanup" ]] ; then
+        _download_kubeconfig $(_get_cluster_id ${CLUSTER_NAME}) ./kubeconfig
+        export KUBECONFIG=./kubeconfig
+    fi
     METADATA=$(cat << EOF
 {
 "uuid" : "${UUID}",

--- a/images/airflow-ansible/Dockerfile
+++ b/images/airflow-ansible/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.2.0
+ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.3.0
 FROM ${BASE_IMAGE}
 USER root
 RUN apt install bc

--- a/images/airflow-managed-services/Dockerfile
+++ b/images/airflow-managed-services/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.2.3
+ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.3.0
 FROM ${BASE_IMAGE} as runtime
 USER root
 RUN curl -L https://go.dev/dl/go1.17.6.linux-amd64.tar.gz -o go1.17.6.linux-amd64.tar.gz


### PR DESCRIPTION
After updating airflow to 2.3.0 version, we need to upgrade container images to the same version
