### PR TITLE
Fix sqlalchemy version

### DIFF
--- a/dags/openshift_nightlies/models/dag_config.py
+++ b/dags/openshift_nightlies/models/dag_config.py
@@ -20,6 +20,6 @@ class DagConfig:
         })
     executor_image: Optional[dict] = field(default_factory=lambda: {
             "repository": "quay.io/cloud-bulldozer",
-            "tag": "2.2.0"
+            "tag": "2.3.0"
         })
     dependencies: Optional[dict] = field(default_factory=lambda: {})

--- a/dags/setup.cfg
+++ b/dags/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     elasticsearch
     apache-airflow-providers-slack
     markupsafe==2.0.1
+    sqlalchemy==1.3.20
 python_requires = >=3.8
 
 [options.extras_require]

--- a/images/airflow-ansible/Dockerfile
+++ b/images/airflow-ansible/Dockerfile
@@ -3,4 +3,5 @@ FROM ${BASE_IMAGE}
 USER root
 RUN apt install bc
 USER airflow
-RUN yes | pip install ansible netaddr sqlalchemy==1.3.20
+RUN yes | pip install ansible netaddr
+RUN yes | pip install sqlalchemy==1.3.20 --force-reinstall

--- a/images/airflow-ansible/Dockerfile
+++ b/images/airflow-ansible/Dockerfile
@@ -3,4 +3,4 @@ FROM ${BASE_IMAGE}
 USER root
 RUN apt install bc
 USER airflow
-RUN yes | pip install ansible netaddr
+RUN yes | pip install ansible netaddr sqlalchemy==1.3.20

--- a/images/airflow-managed-services/Dockerfile
+++ b/images/airflow-managed-services/Dockerfile
@@ -33,4 +33,5 @@ RUN make build
 WORKDIR /opt/airflow/
 USER airflow
 RUN python3 -m pip install --upgrade pip || true
-RUN yes | pip3 install openshift==0.11.0 sqlalchemy==1.3.20 || true
+RUN yes | pip3 install openshift==0.11.0 || true
+RUN yes | pip3 install sqlalchemy==1.3.20 --force-reinstall || true

--- a/images/airflow-managed-services/Dockerfile
+++ b/images/airflow-managed-services/Dockerfile
@@ -33,4 +33,4 @@ RUN make build
 WORKDIR /opt/airflow/
 USER airflow
 RUN python3 -m pip install --upgrade pip || true
-RUN yes | pip3 install openshift==0.11.0 || true
+RUN yes | pip3 install openshift==0.11.0 sqlalchemy==1.3.20 || true


### PR DESCRIPTION
### Description
Latest version of sqlalchemy is incompatible with our airflow+postgres deployment. This PR sets a tested stable version for sqlalchemy. 
Change the version to 2.3.0 in the dag config. 
