### PR TITLE
fixing openshfit version in apache-managed-services-dockerfile

### DIFF
--- a/dags/setup.cfg
+++ b/dags/setup.cfg
@@ -28,7 +28,6 @@ install_requires =
     elasticsearch
     apache-airflow-providers-slack
     markupsafe==2.0.1
-    sqlalchemy==1.3.20
 python_requires = >=3.8
 
 [options.extras_require]

--- a/images/airflow-ansible/Dockerfile
+++ b/images/airflow-ansible/Dockerfile
@@ -4,4 +4,3 @@ USER root
 RUN apt install bc
 USER airflow
 RUN yes | pip install ansible netaddr
-RUN yes | pip install sqlalchemy==1.3.20 --force-reinstall

--- a/images/airflow-managed-services/Dockerfile
+++ b/images/airflow-managed-services/Dockerfile
@@ -33,5 +33,4 @@ RUN make build
 WORKDIR /opt/airflow/
 USER airflow
 RUN python3 -m pip install --upgrade pip || true
-RUN yes | pip3 install openshift==0.11.0 || true
-RUN yes | pip3 install sqlalchemy==1.3.20 --force-reinstall || true
+RUN yes | pip3 install openshift || true


### PR DESCRIPTION
### Description
The reason why managed-services dags were crashing the scheduler is because the managed-services dockerfile was installing an older version of kubernetes which is incompatible with latest airflow.
error log:
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
apache-airflow-providers-cncf-kubernetes 4.0.1 requires kubernetes<24,>=21.7.0, but you have kubernetes 11.0.0 which is incompatible.
```
by installing openshift==0.11.0 an older version of kubernetes gets installed , uninstalling a newer version.
```
STEP 35/36: RUN yes | pip3 install openshift==0.11.0 || true
Collecting openshift==0.11.0
  Downloading openshift-0.11.0.tar.gz (18 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Collecting dictdiffer
  Downloading dictdiffer-0.9.0-py2.py3-none-any.whl (16 kB)
Requirement already satisfied: jinja2 in /home/airflow/.local/lib/python3.8/site-packages (from openshift==0.11.0) (3.0.3)
Collecting kubernetes~=11.0
  Downloading kubernetes-11.0.0-py3-none-any.whl (1.5 MB)

Successfully built openshift
Installing collected packages: dictdiffer, ruamel.yaml.clib, python-string-utils, ruamel.yaml, kubernetes, openshift
  Attempting uninstall: kubernetes
    Found existing installation: kubernetes 23.3.0
    Uninstalling kubernetes-23.3.0:
      Successfully uninstalled kubernetes-23.3.0
```
Also revert the sqlalchemy changes.
