### PR TITLE
adding -y for apt install

### DIFF
--- a/images/airflow-ansible/Dockerfile
+++ b/images/airflow-ansible/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.3.0
 FROM ${BASE_IMAGE}
 USER root
-RUN apt install bc
+RUN apt install bc -y
 USER airflow
 RUN yes | pip install ansible netaddr


### PR DESCRIPTION
### Description
-y is not required to install apt package bc for building the airflow-ansible dockerfile
