### PR TITLE
Task variables

### DIFF
--- a/dags/openshift_nightlies/docs/secrets.md
+++ b/dags/openshift_nightlies/docs/secrets.md
@@ -14,26 +14,17 @@ To resolve this, Airflow lets you [define variables](https://airflow.apache.org/
 
 For users leveraging the `playground` or `tenant` mode of installation benefit from the fact that Airflow instances created with those modes are auto-wired to connect to our [Vault](https://www.vaultproject.io/) instance. This ensures Airflow will work OOTB as our Vault has all of the required variables defined in it. 
 
-## Overriding Vault Variables
+## Variables for specific tasks
 
-If Airflow is connected to a Vault instance, those variables will take precendence over any defined locally within Airflow. In order to allow users to override the variables with their own configurations, users can create a singular `overrides` variable in Airflow that is a JSON blob with mappings of the variable key to the new desired value. 
+It's possible to set variables for a specific dag/task tuple, by default Airflow will try to fetch a secret with the name `<DAG_NAME>-<TASK_NAME>` from a connected vault instance. The variables set in this secret will take precedence to any other variable defined in the task.
 
-Example `overrides` variable:
+Example `4.11-aws-sdn-data-plane-router` variable:
 
 ```json
-
 {
-    "ansible_orchestrator": {
-        "orchestration_host": "my_custom_host",
-        "orchestration_user": "my_custom_user"
-    },
-    "elasticsearch": "my_custom_elastic_url"
+    "TERMINATIONS": "mix"
 }
-
 ```
-
-
-
 
 
 # Supported Variables

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -113,6 +113,9 @@ class E2EBenchmarks():
 
     def _get_benchmark(self, benchmark):
         env = {**self.env, **benchmark.get('env', {}), **{"ES_SERVER": var_loader.get_secret('elasticsearch'), "KUBEADMIN_PASSWORD": environ.get("KUBEADMIN_PASSWORD", "")}}
+        # Fetch variables from a secret with the name <DAG_NAME>-<TASK_NAME>
+        task_variables = var_loader.get_secret(f"{self.dag.dag_id}-{benchmark['name']}")
+        env.update(task_variables)
         task_prefix=f"{self.task_group}-"
         task = BashOperator(
                 task_id=f"{task_prefix if self.task_group != 'benchmarks' else ''}{benchmark['name']}",

--- a/dags/openshift_nightlies/util/var_loader.py
+++ b/dags/openshift_nightlies/util/var_loader.py
@@ -15,19 +15,15 @@ def get_git_user():
     git_user = git_path.split('/')[0]
     return git_user.lower()
 
-def get_secret(name, deserialize_json=False):
-    overrides = get_overrides()
-    if name in overrides:
-        return overrides[name]
-    return Variable.get(name, deserialize_json=deserialize_json)
 
-
-def get_overrides():
-    try:
-        return Variable.get("overrides", deserialize_json=True)
-    except KeyError: 
-        return {}
-    
+def get_secret(name, deserialize_json=False, required=True):
+    if required:
+        return Variable.get(name, deserialize_json=deserialize_json)
+    else:
+        try:
+            return Variable.get(name, deserialize_json=deserialize_json)
+        except KeyError:
+            return {}
 
 
 ### Task Variable Generator


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Allows airflow to fetch arbitrary variables from specific dag/task tuple. This will helpful in case we want to, for example, configure different benchmark behaviors such as different metric profiles, comparison cofigurations, etc. between managed services and general perfscale DAGs.

Also deprecating the old overriding mechanism which turned out to be quite useless.

### Fixes
