### PR TITLE
Remove stale variables

### DIFF
--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -25,7 +25,6 @@ class E2EBenchmarks():
         self.dag_config = config
         self.exec_config = executor.get_executor_config_with_cluster_access(self.dag_config, self.release, task_group=self.task_group)
         self.snappy_creds = var_loader.get_secret("snappy_creds", deserialize_json=True)
-        self.es_gold = var_loader.get_secret("es_gold")
         self.es_server_baseline = var_loader.get_secret("es_server_baseline")
 
         # Specific Task Configuration
@@ -39,7 +38,6 @@ class E2EBenchmarks():
             "SNAPPY_USER_FOLDER": self.git_name,
             "PLATFORM": self.release.platform,
             "TASK_GROUP": self.task_group,
-            "ES_GOLD": self.es_gold,
             "ES_SERVER_BASELINE": self.es_server_baseline
         }
         self.env.update(self.dag_config.dependencies)


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

This variables is not being used in any of the e2e-benchmarking scripts. Let's remove it

### Fixes
