### PR TITLE
ROSA. Selecting channel group and OCP version to install

### DIFF
--- a/dags/openshift_nightlies/config/benchmarks/empty.json
+++ b/dags/openshift_nightlies/config/benchmarks/empty.json
@@ -1,0 +1,3 @@
+{
+    "benchmarks": []
+}

--- a/dags/openshift_nightlies/config/install/rosa/iam-ovn.json
+++ b/dags/openshift_nightlies/config/install/rosa/iam-ovn.json
@@ -6,6 +6,8 @@
     "rosa_environment": "staging",
     "rosa_cli_version": "master",
     "ocm_environment": "stage",
+    "managed_channel_group": "nightly",
+    "managed_ocp_version": "latest",
     "openshift_worker_count": 27,
     "openshift_network_type": "OVNKubernetes",
     "openshift_worker_instance_type": "m5.2xlarge",

--- a/dags/openshift_nightlies/config/install/rosa/iam-sdn.json
+++ b/dags/openshift_nightlies/config/install/rosa/iam-sdn.json
@@ -6,6 +6,8 @@
     "rosa_environment": "staging",
     "rosa_cli_version": "master",
     "ocm_environment": "stage",
+    "managed_channel_group": "nightly",
+    "managed_ocp_version": "latest",
     "openshift_worker_count": 27,
     "openshift_network_type": "OpenShiftSDN",
     "openshift_worker_instance_type": "m5.2xlarge",

--- a/dags/openshift_nightlies/config/install/rosa/ovn-osd.json
+++ b/dags/openshift_nightlies/config/install/rosa/ovn-osd.json
@@ -6,6 +6,8 @@
     "rosa_environment": "staging",
     "rosa_cli_version": "master",
     "ocm_environment": "stage",
+    "managed_channel_group": "nightly",
+    "managed_ocp_version": "latest",
     "openshift_worker_count": 27,
     "openshift_network_type": "OVNKubernetes",
     "openshift_worker_instance_type": "m5.2xlarge",

--- a/dags/openshift_nightlies/config/install/rosa/ovn.json
+++ b/dags/openshift_nightlies/config/install/rosa/ovn.json
@@ -6,6 +6,8 @@
     "rosa_environment": "staging",
     "rosa_cli_version": "master",
     "ocm_environment": "stage",
+    "managed_channel_group": "nightly",
+    "managed_ocp_version": "latest",
     "openshift_worker_count": 27,
     "openshift_network_type": "OVNKubernetes",
     "openshift_worker_instance_type": "m5.2xlarge",

--- a/dags/openshift_nightlies/config/install/rosa/sdn.json
+++ b/dags/openshift_nightlies/config/install/rosa/sdn.json
@@ -6,6 +6,8 @@
     "rosa_environment": "staging",
     "rosa_cli_version": "master",
     "ocm_environment": "stage",
+    "managed_channel_group": "nightly",
+    "managed_ocp_version": "latest",
     "openshift_worker_count": 27,
     "openshift_network_type": "OpenShiftSDN",
     "openshift_worker_instance_type": "m5.2xlarge",

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -127,12 +127,12 @@ platforms:
           install: rosa/ovn.json
           benchmarks: data-plane.json
       - name: iam-ovn-control-plane
-        schedule: "None"
+        schedule: 'None'
         config:
           install: rosa/iam-ovn.json
           benchmarks: control-plane.json
       - name: iam-sdn-control-plane
-        schedule: "None"
+        schedule: 'None'
         config:
           install: rosa/iam-sdn.json
           benchmarks: control-plane.json          


### PR DESCRIPTION
- Add options for running rosa installation on all rosa channels (stable, candidate & nightly)
- Add option for selecting fixed OCP version on ROSA, latest image or prelatest for allowing ugrades.
- Removed schedule for ROSA CCS DAGS
