### PR TITLE
Rename CCS references to IAM on ROSA

### DIFF
--- a/dags/openshift_nightlies/config/install/rosa/iam-ovn.json
+++ b/dags/openshift_nightlies/config/install/rosa/iam-ovn.json
@@ -2,13 +2,13 @@
     "aws_profile": "",
     "aws_access_key_id": "",
     "aws_secret_access_key": "",
-    "aws_authentication_method": "ccs",
+    "aws_authentication_method": "iam",
     "rosa_environment": "staging",
     "rosa_cli_version": "master",
     "ocm_environment": "stage",
     "openshift_worker_count": 27,
-    "openshift_network_type": "OpenShiftSDN",
+    "openshift_network_type": "OVNKubernetes",
     "openshift_worker_instance_type": "m5.2xlarge",
     "machineset_metadata_label_prefix": "machine.openshift.io",
     "openshift_workload_node_instance_type": "m5.2xlarge"
-}
+ }

--- a/dags/openshift_nightlies/config/install/rosa/iam-sdn.json
+++ b/dags/openshift_nightlies/config/install/rosa/iam-sdn.json
@@ -2,13 +2,13 @@
     "aws_profile": "",
     "aws_access_key_id": "",
     "aws_secret_access_key": "",
-    "aws_authentication_method": "ccs",
+    "aws_authentication_method": "iam",
     "rosa_environment": "staging",
     "rosa_cli_version": "master",
     "ocm_environment": "stage",
     "openshift_worker_count": 27,
-    "openshift_network_type": "OVNKubernetes",
+    "openshift_network_type": "OpenShiftSDN",
     "openshift_worker_instance_type": "m5.2xlarge",
     "machineset_metadata_label_prefix": "machine.openshift.io",
     "openshift_workload_node_instance_type": "m5.2xlarge"
- }
+}

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -121,13 +121,13 @@ platforms:
         config:
           install: rosa/ovn.json
           benchmarks: data-plane.json
-      - name: ccs-ovn-control-plane
+      - name: iam-ovn-control-plane
         config:
-          install: rosa/ccs-ovn.json
+          install: rosa/iam-ovn.json
           benchmarks: control-plane.json
-      - name: ccs-sdn-control-plane
+      - name: iam-sdn-control-plane
         config:
-          install: rosa/ccs-sdn.json
+          install: rosa/iam-sdn.json
           benchmarks: control-plane.json          
       - name: osd-ovn-control-plane
         schedule:  "30 12 * * 1,3,5"


### PR DESCRIPTION
It is not correct to use CCS to name non STS authentication method on AWS for ROSA, the correct naming is IAM
