### PR TITLE
Disable schedule on selected dags

### DIFF
--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -127,10 +127,12 @@ platforms:
           install: rosa/ovn.json
           benchmarks: data-plane.json
       - name: iam-ovn-control-plane
+        schedule: "None"
         config:
           install: rosa/iam-ovn.json
           benchmarks: control-plane.json
       - name: iam-sdn-control-plane
+        schedule: "None"
         config:
           install: rosa/iam-sdn.json
           benchmarks: control-plane.json          

--- a/dags/openshift_nightlies/util/manifest.py
+++ b/dags/openshift_nightlies/util/manifest.py
@@ -249,7 +249,8 @@ class Manifest():
     def _get_schedule(self, variant, platform):
         schedules = self.yaml['dagConfig']['schedules']
         if bool(schedules.get("enabled", False)) and platform != "prebuilt" and var_loader.get_git_user() == "cloud-bulldozer":
-            return variant.get('schedule', schedules.get(platform, schedules['default']))
+            schedule = variant.get('schedule', schedules.get(platform, schedules['default']))
+            return schedule if schedule != 'None' else None
         else:
             return None
     


### PR DESCRIPTION
With current configuration, there is no way to disable schedules for a dag.
If there is no schedule line on the manifest, it is applied the default one.

This change allows to keep using default schedule if it is not defined on the dag, or disable for the dag, if it is defined as "None"

There are some dags without schedule, @rsevilla87 @mohit-sheth please review if you want to apply the default one, or the intention was to disable it
- [ACS](https://github.com/cloud-bulldozer/airflow-kubernetes/blob/master/dags/openshift_nightlies/manifest.yaml#L79)
- [Jetsky](https://github.com/cloud-bulldozer/airflow-kubernetes/blob/master/dags/openshift_nightlies/manifest.yaml#L88)
- [Openstack](https://github.com/cloud-bulldozer/airflow-kubernetes/blob/master/dags/openshift_nightlies/manifest.yaml#L93)
- [Prebuilt](https://github.com/cloud-bulldozer/airflow-kubernetes/blob/master/dags/openshift_nightlies/manifest.yaml#L181)