### PR TITLE
Refactor managed services dockerfile to reduce size

### DIFF
--- a/images/airflow-managed-services/Dockerfile
+++ b/images/airflow-managed-services/Dockerfile
@@ -1,14 +1,15 @@
 ARG BASE_IMAGE=quay.io/cloud-bulldozer/airflow:2.3.1
+# Hypershift Compilation
+FROM golang:1.18 AS hypershift
+RUN git clone --branch main https://github.com/openshift/hypershift
+WORKDIR hypershift
+RUN make build
+# Runtime image
 FROM ${BASE_IMAGE} as runtime
 USER root
 RUN curl -L https://go.dev/dl/go1.18.2.linux-amd64.tar.gz -o go1.18.2.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.18.2.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
-RUN mkdir -p /home/airflow/go
-ENV GOPATH=/home/airflow/go
-RUN go install github.com/markbates/pkger/cmd/pkger@latest
-RUN mv $GOPATH/bin/pkger /usr/local/bin/
-ENV GOFLAGS=
 RUN apt update -y
 RUN env ACCEPT_EULA=Y apt upgrade -y
 RUN apt install jq unzip bsdmainutils build-essential libncurses5-dev zlib1g-dev libnss3-dev libgdbm-dev libssl-dev libsqlite3-dev libffi-dev libreadline-dev curl libbz2-dev -y
@@ -17,20 +18,17 @@ RUN curl -L $(curl -s https://api.github.com/repos/openshift-online/ocm-cli/rele
 RUN chmod +x /usr/local/bin/rosa && chmod +x /usr/local/bin/ocm
 RUN /usr/local/bin/rosa download openshift-client
 RUN tar xzvf openshift-client-linux.tar.gz
-RUN curl "https://www.python.org/ftp/python/3.9.9/Python-3.9.9.tar.xz" | tar xJf -
-RUN cd Python-3.9.9 && ./configure --enable-optimizations && make && make altinstall
+RUN mv oc kubectl /usr/local/bin/
 RUN echo "export CLOUDSDK_PYTHON=python3.9" >> /home/airflow/.bashrc
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y
-RUN mv oc kubectl /usr/local/bin/
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip
 RUN ./aws/install
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 RUN echo "airflow ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-RUN git clone --branch main https://github.com/openshift/hypershift
-WORKDIR hypershift
-RUN make build
+COPY --from=hypershift /go/hypershift/bin/hypershift /go/hypershift/bin/hypershift-operator /go/hypershift/bin/control-plane-operator /usr/local/bin/
+RUN cd /usr/local/bin && ln -s control-plane-operator ignition-server && ln -s control-plane-operator konnectivity-socks5-proxy && ln -s control-plane-operator availability-prober && ln -s control-plane-operator token-minter
 WORKDIR /opt/airflow/
 USER airflow
 RUN python3 -m pip install --upgrade pip || true
-RUN yes | pip3 install openshift || true
+RUN yes | pip3 install openshift --upgrade || true


### PR DESCRIPTION
Size of the image is reduced from 7.5G to 5.4G

- Removed python3.9 installation from sources as it is already included in the container as package
- Move hypershift compilation to a build container to avoid storing all the code

I keep go 1.18 manual installation because the latest available as package is 1.15, not enough for compiling ocm (during the installation process).
