### PR TITLE
Fix baremetal variable

### DIFF
--- a/dags/openshift_nightlies/tasks/install/baremetal/jetski.py
+++ b/dags/openshift_nightlies/tasks/install/baremetal/jetski.py
@@ -41,7 +41,8 @@ class BaremetalOpenshiftInstaller(AbstractOpenshiftInstaller):
         }
         
         config['pullsecret'] = json.dumps(config['openshift_install_pull_secret'])
-        config['version'] = var_loader.get_secret(f'{var_loader.get_git_user()}-baremetal_clusterversion') or self.release.release_stream
+        version_variable = f'{var_loader.get_git_user()}-baremetal_clusterversion'
+        config['version'] = var_loader.get_secret(version_variable, required=False) or self.release.release_stream
         config['build'] = self.release.build
         
         # Required Environment Variables for Install script


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Set baremetal_clusterversion as not required, in order to fix:

cc: @mohit-sheth 

### Fixes

```
Broken DAG: [/opt/airflow/dags/repo/dags/openshift_nightlies/dag.py] Traceback (most recent call last):
  File "/opt/airflow/dags/repo/dags/openshift_nightlies/tasks/install/baremetal/jetski.py", line 25, in get_install_task
    install = self._get_task(operation="install")
  File "/opt/airflow/dags/repo/dags/openshift_nightlies/tasks/install/baremetal/jetski.py", line 44, in _get_task
    config['version'] = var_loader.get_secret(f'{var_loader.get_git_user()}-baremetal_clusterversion') or self.release.release_stream
  File "/opt/airflow/dags/repo/dags/openshift_nightlies/util/var_loader.py", line 21, in get_secret
    return Variable.get(name, deserialize_json=deserialize_json)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/variable.py", line 138, in get
    raise KeyError(f'Variable {key} does not exist')
KeyError: 'Variable cloud-bulldozer-baremetal_clusterversion does not exist'
```
