### PR TITLE
ocm - ocp nightly

### DIFF
--- a/dags/openshift_nightlies/config/install/rosa/ocm.json
+++ b/dags/openshift_nightlies/config/install/rosa/ocm.json
@@ -7,6 +7,8 @@
     "rosa_environment": "staging",
     "rosa_cli_version": "master",
     "ocm_environment": "stage",
+    "managed_channel_group": "nightly",
+    "managed_ocp_version": "latest",
     "openshift_worker_count": 3,
     "openshift_network_type": "OpenShiftSDN",
     "openshift_worker_instance_type": "m5.2xlarge",

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -147,7 +147,7 @@ platforms:
           install: rosa/ovn-osd.json
           benchmarks: data-plane.json
       - name: ocm-api-load
-        schedule: "None"
+        schedule: 'None'
         config:
           install: rosa/ocm.json
           benchmarks: ocm-api-load.json


### PR DESCRIPTION
All rosa config files updated to use ocp version from nightly
channel group. This PR updates ocm rosa config file accordingly

### Description

### Fixes
