### PR TITLE
Add DAG for ROSA upgrades

### DIFF
--- a/dags/openshift_nightlies/config/benchmarks/upgrade.json
+++ b/dags/openshift_nightlies/config/benchmarks/upgrade.json
@@ -1,0 +1,34 @@
+{
+    "benchmarks": [
+        {
+            "name": "load-cluster-preupgrade",
+            "workload": "kube-burner",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "cluster-density",
+                "JOB_ITERATIONS": "500",
+                "JOB_TIMEOUT": "18000",
+                "STEP_SIZE": "30s",
+                "QPS": "20",
+                "BURST": "20",
+                "LOG_LEVEL": "info",
+                "CLEANUP_WHEN_FINISH": "false",
+                "CLEANUP": "true",
+                "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
+            }
+        },
+        {
+            "name": "upgrades",
+            "workload": "upgrade-perf",
+            "command": "./run_upgrade_fromgit.sh",
+            "env": {
+                "LATEST": "true",
+                "ROSA_VERSION_CHANNEL": "candidate",
+                "TIMEOUT": "400",
+                "POLL_INTERVAL": "10",
+		"ES_INDEX": "managedservices-timings"
+            },
+	    "executor_image": "airflow-managed-services"
+        }
+   ]
+}

--- a/dags/openshift_nightlies/config/install/rosa/upgrade.json
+++ b/dags/openshift_nightlies/config/install/rosa/upgrade.json
@@ -1,0 +1,16 @@
+{
+    "aws_profile": "",
+    "aws_access_key_id": "",
+    "aws_secret_access_key": "",
+    "aws_authentication_method": "sts",
+    "rosa_environment": "staging",
+    "rosa_cli_version": "container",
+    "ocm_environment": "stage",
+    "managed_channel_group": "candidate",
+    "managed_ocp_version": "prelatest",
+    "openshift_worker_count": 24,
+    "openshift_network_type": "OVNKubernetes",
+    "openshift_worker_instance_type": "m5.2xlarge",
+    "machineset_metadata_label_prefix": "machine.openshift.io",
+    "openshift_workload_node_instance_type": "m5.2xlarge"
+}

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -151,6 +151,11 @@ platforms:
         config:
           install: rosa/ocm.json
           benchmarks: ocm-api-load.json
+      - name: rosa-upgrade
+        schedule:  "20 12 * * 3"
+        config:
+          install: rosa/upgrade.json
+          benchmarks: upgrade.json
 
   rogcp:
     versions: ["4.10", 4.11]

--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -198,7 +198,7 @@ setup(){
         aws iam get-user | jq -r .User.UserName        
     else
         export ROSA_CLI_VERSION=$(cat ${json_file} | jq -r .rosa_cli_version)
-        if [[ ${ROSA_CLI_VERSION} != "null" ]]; then
+        if [[ ${ROSA_CLI_VERSION} != "container" ]]; then
             ROSA_CLI_FORK=$(cat ${json_file} | jq -r .rosa_cli_fork)
             git clone -q --depth=1 --single-branch --branch ${ROSA_CLI_VERSION} ${ROSA_CLI_FORK}
             pushd rosa
@@ -321,7 +321,7 @@ EOF
     TOTAL_TIME=0
     for i in ${INDEXDATA[@]} ; do IFS="-" ; set -- $i
         METADATA="${METADATA}, \"$1\":\"$2\""
-	if [ $1 != "day2operations" ] ; then
+	if [ $1 != "day2operations" ] && [ $1 != "cleanup" ] ; then
 	    INSTALL_TIME=$((${INSTALL_TIME} + $2))
 	    TOTAL_TIME=$((${TOTAL_TIME} + $2))
 	else
@@ -332,8 +332,8 @@ EOF
     METADATA="${METADATA}, \"install_time\":\"${INSTALL_TIME}\""
     METADATA="${METADATA}, \"total_time\":\"${TOTAL_TIME}\""
     METADATA="${METADATA} }"
-    printf "Indexing installation timings to ${ES_SERVER}/managedservices-install-timings"
-    curl -k -sS -X POST -H "Content-type: application/json" ${ES_SERVER}/managedservices-install-timings/_doc -d "${METADATA}" -o /dev/null
+    printf "Indexing installation timings to ES"
+    curl -k -sS -X POST -H "Content-type: application/json" ${ES_SERVER}/managedservices-timings/_doc -d "${METADATA}" -o /dev/null
     unset KUBECONFIG
     return 0
 }

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -23,7 +23,6 @@ class E2EBenchmarks():
         self.release = release
         self.task_group = task_group
         self.dag_config = config
-        self.exec_config = executor.get_executor_config_with_cluster_access(self.dag_config, self.release, task_group=self.task_group)
         self.snappy_creds = var_loader.get_secret("snappy_creds", deserialize_json=True)
         self.es_server_baseline = var_loader.get_secret("es_server_baseline")
 
@@ -118,6 +117,10 @@ class E2EBenchmarks():
         task_variables = var_loader.get_secret(f"{self.dag.dag_id}-{benchmark['name']}", True, False)
         env.update(task_variables)
         task_prefix=f"{self.task_group}-"
+        if 'executor_image' in benchmark:
+            self.exec_config = executor.get_executor_config_with_cluster_access(self.dag_config, self.release, executor_image=benchmark['executor_image'], task_group=self.task_group)
+        else:
+            self.exec_config = executor.get_executor_config_with_cluster_access(self.dag_config, self.release, task_group=self.task_group)
         task = BashOperator(
                 task_id=f"{task_prefix if self.task_group != 'benchmarks' else ''}{benchmark['name']}",
                 depends_on_past=False,


### PR DESCRIPTION
Adding a DAG for installing the latest-1 version of ROSA on candidate channel and then load the cluster using cluster-density and finally upgrade to the latest version.

I have added the possibility to select the executor image also on benchmarks, if no parameter is added, it will be using by default the current one.

This is required because upgrade test requires the rosa binary, not installed in the default airflow container image.