### PR TITLE
Trigger rule for large-scale DAGs

### DIFF
--- a/dags/openshift_nightlies/config/benchmarks/extra-large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/extra-large-control-plane.json
@@ -62,6 +62,7 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "node-density",

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
@@ -52,6 +52,7 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "node-density",

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
@@ -42,6 +42,7 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
+            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "node-density",


### PR DESCRIPTION
### Description

Let's set a custom trigger_rule for the second benchmark of the large-scale tests, so in case cluster-density fails, we can execute node-density afterwards

