### PR TITLE
Change to use fixed version on rosa cli as latest has a bug

### DIFF
--- a/dags/openshift_nightlies/config/install/rosa/iam-ovn.json
+++ b/dags/openshift_nightlies/config/install/rosa/iam-ovn.json
@@ -4,7 +4,7 @@
     "aws_secret_access_key": "",
     "aws_authentication_method": "iam",
     "rosa_environment": "staging",
-    "rosa_cli_version": "master",
+    "rosa_cli_version": "container",
     "ocm_environment": "stage",
     "managed_channel_group": "nightly",
     "managed_ocp_version": "latest",

--- a/dags/openshift_nightlies/config/install/rosa/iam-sdn.json
+++ b/dags/openshift_nightlies/config/install/rosa/iam-sdn.json
@@ -4,7 +4,7 @@
     "aws_secret_access_key": "",
     "aws_authentication_method": "iam",
     "rosa_environment": "staging",
-    "rosa_cli_version": "master",
+    "rosa_cli_version": "container",
     "ocm_environment": "stage",
     "managed_channel_group": "nightly",
     "managed_ocp_version": "latest",

--- a/dags/openshift_nightlies/config/install/rosa/ocm.json
+++ b/dags/openshift_nightlies/config/install/rosa/ocm.json
@@ -5,7 +5,7 @@
     "aws_authentication_method": "sts",
     "aws_account_id": "",
     "rosa_environment": "staging",
-    "rosa_cli_version": "master",
+    "rosa_cli_version": "container",
     "ocm_environment": "stage",
     "managed_channel_group": "nightly",
     "managed_ocp_version": "latest",

--- a/dags/openshift_nightlies/config/install/rosa/ovn-osd.json
+++ b/dags/openshift_nightlies/config/install/rosa/ovn-osd.json
@@ -4,7 +4,7 @@
     "aws_access_key_id": "",
     "aws_secret_access_key": "",
     "rosa_environment": "staging",
-    "rosa_cli_version": "master",
+    "rosa_cli_version": "container",
     "ocm_environment": "stage",
     "managed_channel_group": "nightly",
     "managed_ocp_version": "latest",

--- a/dags/openshift_nightlies/config/install/rosa/ovn.json
+++ b/dags/openshift_nightlies/config/install/rosa/ovn.json
@@ -4,7 +4,7 @@
     "aws_secret_access_key": "",
     "aws_authentication_method": "sts",
     "rosa_environment": "staging",
-    "rosa_cli_version": "master",
+    "rosa_cli_version": "container",
     "ocm_environment": "stage",
     "managed_channel_group": "nightly",
     "managed_ocp_version": "latest",

--- a/dags/openshift_nightlies/config/install/rosa/sdn.json
+++ b/dags/openshift_nightlies/config/install/rosa/sdn.json
@@ -4,7 +4,7 @@
     "aws_secret_access_key": "",
     "aws_authentication_method": "sts",
     "rosa_environment": "staging",
-    "rosa_cli_version": "master",
+    "rosa_cli_version": "container",
     "ocm_environment": "stage",
     "managed_channel_group": "nightly",
     "managed_ocp_version": "latest",


### PR DESCRIPTION
Latest version of rosa cli has a bug on creating the machinepools, making the DAG fails.

Version 1.2.2 (last published) do not have the error, so we have to move config file to not to compile latest rosa cli
