### PR TITLE
updated fw ports for uperf

### DIFF
--- a/dags/openshift_nightlies/scripts/install/hypershift.sh
+++ b/dags/openshift_nightlies/scripts/install/hypershift.sh
@@ -201,8 +201,8 @@ update_fw(){
         echo "Add rules to group $group.."
         aws ec2 authorize-security-group-ingress --group-id $group --protocol tcp --port 22 --cidr 0.0.0.0/0
         aws ec2 authorize-security-group-ingress --group-id $group --protocol tcp --port 2022 --cidr 0.0.0.0/0
-        aws ec2 authorize-security-group-ingress --group-id $group --protocol tcp --port 20000-30109 --cidr 0.0.0.0/0
-        aws ec2 authorize-security-group-ingress --group-id $group --protocol udp --port 20000-30109 --cidr 0.0.0.0/0
+        aws ec2 authorize-security-group-ingress --group-id $group --protocol tcp --port 20000-31000 --cidr 0.0.0.0/0
+        aws ec2 authorize-security-group-ingress --group-id $group --protocol udp --port 20000-31000 --cidr 0.0.0.0/0
         aws ec2 authorize-security-group-ingress --group-id $group --protocol tcp --port 32768-60999 --cidr 0.0.0.0/0
         aws ec2 authorize-security-group-ingress --group-id $group --protocol udp --port 32768-60999 --cidr 0.0.0.0/0
     done

--- a/dags/openshift_nightlies/scripts/install/ocm_gcp.sh
+++ b/dags/openshift_nightlies/scripts/install/ocm_gcp.sh
@@ -99,7 +99,7 @@ postinstall(){
     gcloud compute firewall-rules create ${NETWORK_NAME}-icmp --network ${NETWORK_NAME} --priority 101 --description 'scale-ci allow icmp' --allow icmp
     gcloud compute firewall-rules create ${NETWORK_NAME}-ssh --network ${NETWORK_NAME} --direction INGRESS --priority 102 --description 'scale-ci allow ssh' --allow tcp:22
     gcloud compute firewall-rules create ${NETWORK_NAME}-pbench --network ${NETWORK_NAME} --direction INGRESS --priority 103 --description 'scale-ci allow pbench-agents' --allow tcp:2022
-    gcloud compute firewall-rules create ${NETWORK_NAME}-net --network ${NETWORK_NAME} --direction INGRESS --priority 104 --description 'scale-ci allow tcp,udp network tests' --rules tcp:20000-30109,udp:20000-30109 --action allow
+    gcloud compute firewall-rules create ${NETWORK_NAME}-net --network ${NETWORK_NAME} --direction INGRESS --priority 104 --description 'scale-ci allow tcp,udp network tests' --rules tcp:20000-31000,udp:20000-31000 --action allow
     gcloud compute firewall-rules create ${NETWORK_NAME}-hostnet --network ${NETWORK_NAME} --priority 105 --description 'scale-ci allow tcp,udp hostnetwork tests' --rules tcp:32768-60999,udp:32768-60999 --action allow
 }
 

--- a/dags/openshift_nightlies/scripts/utils/rosa_post_install.py
+++ b/dags/openshift_nightlies/scripts/utils/rosa_post_install.py
@@ -58,8 +58,8 @@ def _aws_config(nodes,clustername,jsonfile):
 
     sec_group_cmds = ["aws ec2 authorize-security-group-ingress --group-id ITEM --protocol tcp --port 22 --cidr 0.0.0.0/0",
                       "aws ec2 authorize-security-group-ingress --group-id ITEM --protocol tcp --port 2022 --cidr 0.0.0.0/0",
-                      "aws ec2 authorize-security-group-ingress --group-id ITEM --protocol tcp --port 20000-30109 --cidr 0.0.0.0/0",
-                      "aws ec2 authorize-security-group-ingress --group-id ITEM --protocol udp --port 20000-30109 --cidr 0.0.0.0/0",
+                      "aws ec2 authorize-security-group-ingress --group-id ITEM --protocol tcp --port 20000-31000 --cidr 0.0.0.0/0",
+                      "aws ec2 authorize-security-group-ingress --group-id ITEM --protocol udp --port 20000-31000 --cidr 0.0.0.0/0",
                       "aws ec2 authorize-security-group-ingress --group-id ITEM --protocol tcp --port 32768-60999 --cidr 0.0.0.0/0",
                       "aws ec2 authorize-security-group-ingress --group-id ITEM --protocol udp --port 32768-60999 --cidr 0.0.0.0/0"]
     for item in sec_group_list:


### PR DESCRIPTION
### Description
Uperf port allocation logic has been updated recently to be dynamic based on the number of pairs [here](https://github.com/cloud-bulldozer/benchmark-operator/pull/755/files#diff-12d1d181bb9b7ad8b89e717593b31d6ea210f5f205deb34c0a4c2852a5ebe0a5), so opening the ports wider to support that in AWS security groups and GCP FW rules

Good catch @vishnuchalla 

### Fixes
