### PR TITLE
Allow passing of install task variables to downstream tasks of a dag

### DIFF
--- a/dags/openshift_nightlies/scripts/install/ocm_gcp.sh
+++ b/dags/openshift_nightlies/scripts/install/ocm_gcp.sh
@@ -103,6 +103,16 @@ postinstall(){
     gcloud compute firewall-rules create ${NETWORK_NAME}-hostnet --network ${NETWORK_NAME} --priority 105 --description 'scale-ci allow tcp,udp hostnetwork tests' --rules tcp:32768-60999,udp:32768-60999 --action allow
 }
 
+display_install_data(){
+    IFS='@'
+    # Read the xcom pushed by install task and store it into an array based on '@' as delimiter 
+    read -ra newarr <<< "$InstallUUID"
+    clustername="${newarr[0]}"
+    installuuid="${newarr[1]}"
+    echo "Cluster Name = ${clustername}"
+    echo "Install UUID = ${installuuid}"
+}
+
 cleanup(){
     ocm delete cluster $(_get_cluster_id ${CLUSTER_NAME})
     ocm logout
@@ -148,5 +158,6 @@ if [[ "$operation" == "install" ]]; then
 
 elif [[ "$operation" == "cleanup" ]]; then
     printf "Running Cleanup Steps"
+    display_install_data
     cleanup
 fi

--- a/dags/openshift_nightlies/scripts/install/ocm_gcp.sh
+++ b/dags/openshift_nightlies/scripts/install/ocm_gcp.sh
@@ -106,7 +106,7 @@ postinstall(){
 display_install_data(){
     IFS='@'
     # Read the xcom pushed by install task and store it into an array based on '@' as delimiter 
-    read -ra newarr <<< "$InstallUUID"
+    read -ra newarr <<< "$Install_vars"
     clustername="${newarr[0]}"
     installuuid="${newarr[1]}"
     echo "Cluster Name = ${clustername}"

--- a/dags/openshift_nightlies/scripts/install/ocm_gcp.sh
+++ b/dags/openshift_nightlies/scripts/install/ocm_gcp.sh
@@ -144,6 +144,7 @@ if [[ "$operation" == "install" ]]; then
         printf "INFO: Cluster ${CLUSTER_NAME} already installed but not ready, exiting..."
 	exit 1
     fi
+    echo "${CLUSTER_NAME}@${UUID}"
 
 elif [[ "$operation" == "cleanup" ]]; then
     printf "Running Cleanup Steps"

--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -341,7 +341,7 @@ EOF
 display_install_data(){
     IFS='@'
     # Read the xcom pushed by install task and store it into an array based on '@' as delimiter 
-    read -ra newarr <<< "$InstallUUID"
+    read -ra newarr <<< "$Install_vars"
     clustername="${newarr[0]}"
     installuuid="${newarr[1]}"
     echo "Cluster Name = ${clustername}"

--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -338,6 +338,17 @@ EOF
     return 0
 }
 
+display_install_data(){
+    IFS='@'
+    # Read the xcom pushed by install task and store it into an array based on '@' as delimiter 
+    read -ra newarr <<< "$InstallUUID"
+
+    clustername="${newarr[0]}"
+    installuuid="${newarr[1]}"
+    echo "Cluster Name = ${clustername}"
+    echo "Install UUID = ${installuuid}"
+}
+
 cleanup(){
     if [[ $INSTALL_METHOD == "osd" ]]; then
         ocm delete cluster $(_get_cluster_id ${CLUSTER_NAME})
@@ -377,9 +388,11 @@ if [[ "$operation" == "install" ]]; then
         printf "INFO: Cluster ${CLUSTER_NAME} already installed but not ready, exiting..."
 	    exit 1
     fi
+    echo "${CLUSTER_NAME}@${UUID}"
 
 elif [[ "$operation" == "cleanup" ]]; then
     printf "Running Cleanup Steps"
+    display_install_data
     cleanup
     index_metadata
     rosa logout

--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -342,7 +342,6 @@ display_install_data(){
     IFS='@'
     # Read the xcom pushed by install task and store it into an array based on '@' as delimiter 
     read -ra newarr <<< "$InstallUUID"
-
     clustername="${newarr[0]}"
     installuuid="${newarr[1]}"
     echo "Cluster Name = ${clustername}"

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -76,14 +76,12 @@ display_install_data(){
         IFS='@'
         # Read the xcom pushed by install task and store it into an array based on '@' as delimiter 
         read -ra newarr <<< "$InstallUUID"
-
         clustername="${newarr[0]}"
         installuuid="${newarr[1]}"
         echo "Cluster Name = ${clustername}"
         echo "Install UUID = ${installuuid}"
     fi
 }
-
 
 export UUID=$(uuidgen | head -c8)-$AIRFLOW_CTX_TASK_ID-$(date '+%Y%m%d')
 echo "############################################"

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -72,7 +72,7 @@ EOF
 }
 
 display_install_data(){    
-    if [[ $PLATFORM == "rosa" ]]; then
+    if [[ $PLATFORM == "rosa" || $PLATFORM == "rogcp" ]]; then
         IFS='@'
         # Read the xcom pushed by install task and store it into an array based on '@' as delimiter 
         read -ra newarr <<< "$InstallUUID"

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -75,7 +75,7 @@ display_install_data(){
     if [[ $PLATFORM == "rosa" || $PLATFORM == "rogcp" ]]; then
         IFS='@'
         # Read the xcom pushed by install task and store it into an array based on '@' as delimiter 
-        read -ra newarr <<< "$InstallUUID"
+        read -ra newarr <<< "$Install_vars"
         clustername="${newarr[0]}"
         installuuid="${newarr[1]}"
         echo "Cluster Name = ${clustername}"

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -70,6 +70,21 @@ EOF
         exit 1
     fi
 }
+
+display_install_data(){    
+    if [[ $PLATFORM == "rosa" ]]; then
+        IFS='@'
+        # Read the xcom pushed by install task and store it into an array based on '@' as delimiter 
+        read -ra newarr <<< "$InstallUUID"
+
+        clustername="${newarr[0]}"
+        installuuid="${newarr[1]}"
+        echo "Cluster Name = ${clustername}"
+        echo "Install UUID = ${installuuid}"
+    fi
+}
+
+
 export UUID=$(uuidgen | head -c8)-$AIRFLOW_CTX_TASK_ID-$(date '+%Y%m%d')
 echo "############################################"
 echo "# Benchmark UUID: ${UUID}"
@@ -80,6 +95,7 @@ if [[ $PLATFORM == "baremetal" ]]; then
     run_baremetal_benchmark
     echo $UUID
 else
+    display_install_data
     setup
     cd /home/airflow/workspace/e2e-benchmarking/workloads/$workload
     

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -128,7 +128,7 @@ class E2EBenchmarks():
                 retries=0,
                 trigger_rule=benchmark.get("trigger_rule", "all_success"),
                 dag=self.dag,
-                env=env,
+                env={ **env , "InstallUUID": '{{ ti.xcom_pull(task_ids="install")}}'},
                 do_xcom_push=True,
                 execution_timeout=timedelta(seconds=21600),
                 executor_config=self.exec_config

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -112,7 +112,7 @@ class E2EBenchmarks():
         benchmark >> indexer 
 
     def _get_benchmark(self, benchmark):
-        env = {**self.env, "InstallUUID": '{{ ti.xcom_pull(task_ids="install")}}', **benchmark.get('env', {}), **{"ES_SERVER": var_loader.get_secret('elasticsearch'), "KUBEADMIN_PASSWORD": environ.get("KUBEADMIN_PASSWORD", "")}}
+        env = {**self.env, "Install_vars": '{{ ti.xcom_pull(task_ids="install")}}', **benchmark.get('env', {}), **{"ES_SERVER": var_loader.get_secret('elasticsearch'), "KUBEADMIN_PASSWORD": environ.get("KUBEADMIN_PASSWORD", "")}}
         # Fetch variables from a secret with the name <DAG_NAME>-<TASK_NAME>
         task_variables = var_loader.get_secret(f"{self.dag.dag_id}-{benchmark['name']}", True, False)
         env.update(task_variables)

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -112,7 +112,7 @@ class E2EBenchmarks():
         benchmark >> indexer 
 
     def _get_benchmark(self, benchmark):
-        env = {**self.env, **benchmark.get('env', {}), **{"ES_SERVER": var_loader.get_secret('elasticsearch'), "KUBEADMIN_PASSWORD": environ.get("KUBEADMIN_PASSWORD", "")}}
+        env = {**self.env, "InstallUUID": '{{ ti.xcom_pull(task_ids="install")}}', **benchmark.get('env', {}), **{"ES_SERVER": var_loader.get_secret('elasticsearch'), "KUBEADMIN_PASSWORD": environ.get("KUBEADMIN_PASSWORD", "")}}
         # Fetch variables from a secret with the name <DAG_NAME>-<TASK_NAME>
         task_variables = var_loader.get_secret(f"{self.dag.dag_id}-{benchmark['name']}", True, False)
         env.update(task_variables)
@@ -128,7 +128,7 @@ class E2EBenchmarks():
                 retries=0,
                 trigger_rule=benchmark.get("trigger_rule", "all_success"),
                 dag=self.dag,
-                env={ **env , "InstallUUID": '{{ ti.xcom_pull(task_ids="install")}}'},
+                env=env,
                 do_xcom_push=True,
                 execution_timeout=timedelta(seconds=21600),
                 executor_config=self.exec_config

--- a/dags/openshift_nightlies/tasks/install/rogcp/rogcp.py
+++ b/dags/openshift_nightlies/tasks/install/rogcp/rogcp.py
@@ -26,6 +26,7 @@ class RoGCPInstaller(AbstractOpenshiftInstaller):
     def _get_task(self, operation="install", trigger_rule="all_success"):
         self._setup_task(operation=operation)
         command=f"{constants.root_dag_dir}/scripts/install/ocm_gcp.sh -v {self.release.version} -j /tmp/{self.release_name}-{operation}-task.json -o {operation}"
+        env={ **self.env , "InstallUUID": '{{ ti.xcom_pull(task_ids="install")}}'}
         return BashOperator(
             task_id=f"{operation}",
             depends_on_past=False,
@@ -34,5 +35,5 @@ class RoGCPInstaller(AbstractOpenshiftInstaller):
             dag=self.dag,
             trigger_rule=trigger_rule,
             executor_config=self.exec_config,
-            env=self.env
+            env=env
         )

--- a/dags/openshift_nightlies/tasks/install/rogcp/rogcp.py
+++ b/dags/openshift_nightlies/tasks/install/rogcp/rogcp.py
@@ -26,7 +26,7 @@ class RoGCPInstaller(AbstractOpenshiftInstaller):
     def _get_task(self, operation="install", trigger_rule="all_success"):
         self._setup_task(operation=operation)
         command=f"{constants.root_dag_dir}/scripts/install/ocm_gcp.sh -v {self.release.version} -j /tmp/{self.release_name}-{operation}-task.json -o {operation}"
-        env={ **self.env , "InstallUUID": '{{ ti.xcom_pull(task_ids="install")}}'}
+        env={ **self.env , "Install_vars": '{{ ti.xcom_pull(task_ids="install")}}'}
         return BashOperator(
             task_id=f"{operation}",
             depends_on_past=False,

--- a/dags/openshift_nightlies/tasks/install/rosa/rosa.py
+++ b/dags/openshift_nightlies/tasks/install/rosa/rosa.py
@@ -26,7 +26,7 @@ class RosaInstaller(AbstractOpenshiftInstaller):
     def _get_task(self, operation="install", trigger_rule="all_success"):
         self._setup_task(operation=operation)
         command=f"{constants.root_dag_dir}/scripts/install/rosa.sh -v {self.release.version} -j /tmp/{self.release_name}-{operation}-task.json -o {operation}"
-
+        env={ **self.env , "InstallUUID": '{{ ti.xcom_pull(task_ids="install")}}'}
         return BashOperator(
             task_id=f"{operation}",
             depends_on_past=False,
@@ -35,5 +35,5 @@ class RosaInstaller(AbstractOpenshiftInstaller):
             dag=self.dag,
             trigger_rule=trigger_rule,
             executor_config=self.exec_config,
-            env={ **self.env , "InstallUUID": '{{ ti.xcom_pull(task_ids="install")}}'}
+            env=env
         )

--- a/dags/openshift_nightlies/tasks/install/rosa/rosa.py
+++ b/dags/openshift_nightlies/tasks/install/rosa/rosa.py
@@ -35,5 +35,5 @@ class RosaInstaller(AbstractOpenshiftInstaller):
             dag=self.dag,
             trigger_rule=trigger_rule,
             executor_config=self.exec_config,
-            env=self.env
+            env={ **self.env , "InstallUUID": '{{ ti.xcom_pull(task_ids="install")}}'}
         )

--- a/dags/openshift_nightlies/tasks/install/rosa/rosa.py
+++ b/dags/openshift_nightlies/tasks/install/rosa/rosa.py
@@ -26,7 +26,7 @@ class RosaInstaller(AbstractOpenshiftInstaller):
     def _get_task(self, operation="install", trigger_rule="all_success"):
         self._setup_task(operation=operation)
         command=f"{constants.root_dag_dir}/scripts/install/rosa.sh -v {self.release.version} -j /tmp/{self.release_name}-{operation}-task.json -o {operation}"
-        env={ **self.env , "InstallUUID": '{{ ti.xcom_pull(task_ids="install")}}'}
+        env={ **self.env , "Install_vars": '{{ ti.xcom_pull(task_ids="install")}}'}
         return BashOperator(
             task_id=f"{operation}",
             depends_on_past=False,

--- a/dags/openshift_nightlies/tasks/utils/final_dag_status.py
+++ b/dags/openshift_nightlies/tasks/utils/final_dag_status.py
@@ -8,6 +8,7 @@ from airflow.operators.python import PythonOperator
 
 
 def final_status(**kwargs):
+    ti = kwargs['ti']
     failed_tasks=[]
     for task_instance in kwargs['dag_run'].get_task_instances():
         if "index" in task_instance.task_id:


### PR DESCRIPTION
### Description
This fix makes it possible to pass variables generated in the install task namely the cluster name and UUID of the install task for rosa and rogcp dags. The passed variables can be accessed by any of the following tasks(benchmarks,cleanup etc) in the dag.  
A limitation of the bash operator is that only a single string can be passed from a task(script), so a concatenation of the above 2 vars, separated by '@' delimiter is passed, the receiving tasks have to separate the 2  from the pulled string. 
Dag run eg: [dag link](http://harshith-umesh-checkvar-airflow.apps.sailplane.perf.lab.eng.rdu2.redhat.com/dags/4.11-rosa-iam-sdn-control-plane/graph?root=&execution_date=2022-06-27T09%3A46%3A05.574981%2B00%3A00) 
The passed string is accessible to the benchmark scripts and the cleanup script. 
### Fixes
https://issues.redhat.com/browse/PERFSCALE-1520 