### PR TITLE
Removed the version from ansible 

### DIFF
--- a/images/airflow-jetski/Dockerfile
+++ b/images/airflow-jetski/Dockerfile
@@ -3,7 +3,8 @@ FROM quay.io/centos/centos:stream8
 ENV DISABLE_PODMAN=true
 
 RUN dnf -y install python3.8 gcc platform-python-devel epel-release --nodocs
-RUN dnf --enablerepo=epel -y install sudo sshpass openssh-clients git ipmitool ansible-2.9.27 python3-dns python3-netaddr ipmitool --nodocs
+#RUN dnf --enablerepo=epel -y install sudo sshpass openssh-clients git ipmitool ansible-2.9.27 python3-dns python3-netaddr ipmitool --nodocs
+RUN dnf --enablerepo=epel -y install sudo sshpass openssh-clients git ipmitool ansible python3-dns python3-netaddr ipmitool --nodocs
 
 RUN pip3.8 install update
 RUN pip3.8 install click idna==2.10 kubernetes==11.0.0 openshift==0.11.2 # due to apache-airflow dependency version limit


### PR DESCRIPTION
The ansible version we used has vanished from the repo. I've taken the version part away in the Dockerfile, so that we run with the latest at the time the images is being built. I have no idea how to ensure that jetski et.al work with that version, so this is a shot in the dark

### Description
removed ansible version 

### Fixes
image wasn't building since the package was not available 
