### PR TITLE
Only login on ocp when platform is ARO

### DIFF
--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -25,7 +25,7 @@ setup(){
 
     export PATH=$PATH:$(pwd)
 
-    if [[ ! -z "$KUBEADMIN_PASSWORD" ]]; then
+    if [[ ! -z "$KUBEADMIN_PASSWORD" ]] && [[ $PLATFORM == "aro" ]]; then
         oc login -u kubeadmin -p $KUBEADMIN_PASSWORD --insecure-skip-tls-verify
     fi
 }


### PR DESCRIPTION
When working with managed services on gcp, username created cannot label nodes, so we exclude login on the cluster on this platform and use only kubeconfig
