### PR TITLE
Update hypershift_cli_version to release-4.11

### DIFF
--- a/dags/openshift_nightlies/config/install/hypershift/none-type.json
+++ b/dags/openshift_nightlies/config/install/hypershift/none-type.json
@@ -1,6 +1,6 @@
 {
     "cluster_install_method": "osd",
-    "hypershift_cli_version": "main",
+    "hypershift_cli_version": "release-4.11",
     "ocm_environment": "stage",
     "rosa_environment": "staging",
     "managed_channel_group": "nightly",

--- a/dags/openshift_nightlies/config/install/hypershift/ovn-p75.json
+++ b/dags/openshift_nightlies/config/install/hypershift/ovn-p75.json
@@ -1,6 +1,6 @@
 {
     "cluster_install_method": "osd",
-    "hypershift_cli_version": "main",
+    "hypershift_cli_version": "release-4.11",
     "ocm_environment": "stage",
     "rosa_environment": "staging",
     "managed_channel_group": "nightly",

--- a/dags/openshift_nightlies/config/install/hypershift/ovn-p90.json
+++ b/dags/openshift_nightlies/config/install/hypershift/ovn-p90.json
@@ -1,6 +1,6 @@
 {
     "cluster_install_method": "osd",
-    "hypershift_cli_version": "main",
+    "hypershift_cli_version": "release-4.11",
     "ocm_environment": "stage",
     "rosa_environment": "staging",
     "managed_channel_group": "nightly",

--- a/dags/openshift_nightlies/config/install/hypershift/rosa-none-type.json
+++ b/dags/openshift_nightlies/config/install/hypershift/rosa-none-type.json
@@ -5,7 +5,7 @@
     "aws_secret_access_key": "",
     "rosa_environment": "staging",
     "rosa_cli_version": "master",
-    "hypershift_cli_version": "main",
+    "hypershift_cli_version": "release-4.11",
     "ocm_environment": "stage",
     "managed_channel_group": "nightly",
     "managed_ocp_version": "latest",    

--- a/dags/openshift_nightlies/config/install/hypershift/rosa-ovn.json
+++ b/dags/openshift_nightlies/config/install/hypershift/rosa-ovn.json
@@ -5,7 +5,7 @@
     "aws_secret_access_key": "",
     "rosa_environment": "staging",
     "rosa_cli_version": "master",
-    "hypershift_cli_version": "main",
+    "hypershift_cli_version": "release-4.11",
     "ocm_environment": "stage",
     "managed_channel_group": "nightly",
     "managed_ocp_version": "latest",    

--- a/dags/openshift_nightlies/config/install/hypershift/rosa-sdn.json
+++ b/dags/openshift_nightlies/config/install/hypershift/rosa-sdn.json
@@ -5,7 +5,7 @@
     "aws_secret_access_key": "",
     "rosa_environment": "staging",
     "rosa_cli_version": "master",
-    "hypershift_cli_version": "main",
+    "hypershift_cli_version": "release-4.11",
     "ocm_environment": "stage",
     "managed_channel_group": "nightly",
     "managed_ocp_version": "latest",    

--- a/dags/openshift_nightlies/config/install/hypershift/sdn.json
+++ b/dags/openshift_nightlies/config/install/hypershift/sdn.json
@@ -1,6 +1,6 @@
 {
     "cluster_install_method": "osd",
-    "hypershift_cli_version": "main",
+    "hypershift_cli_version": "release-4.11",
     "ocm_environment": "stage",
     "rosa_environment": "staging",
     "managed_channel_group": "nightly",


### PR DESCRIPTION
### Description
Leaving the hypershift_cli_version on main was causing issues with version mismatches. This statically sets it to release-4.11

### Fixes
