### PR TITLE
Adding infra node NoSchedule toleration to Grafana Agent

### DIFF
--- a/dags/openshift_nightlies/scripts/utils/templates/grafana-agent.yaml
+++ b/dags/openshift_nightlies/scripts/utils/templates/grafana-agent.yaml
@@ -71,6 +71,10 @@ spec:
               matchExpressions:
               - key: node-role.kubernetes.io/infra
                 operator: Exists
+      tolerations:
+      - key: node-role.kubernetes.io/infra
+        operator: Equal
+        effect: NoSchedule
       containers:
       - args:
         - --config.file=/etc/agent/agent.yaml


### PR DESCRIPTION
### Description
The grafana agent was ending up on worker nodes due to infra nodes having a NoSchedule taint.

### Fixes
