### PR TITLE
Use m6i instances for managed services

### DIFF
--- a/dags/openshift_nightlies/config/install/rosa/iam-ovn.json
+++ b/dags/openshift_nightlies/config/install/rosa/iam-ovn.json
@@ -10,7 +10,7 @@
     "managed_ocp_version": "latest",
     "openshift_worker_count": 27,
     "openshift_network_type": "OVNKubernetes",
-    "openshift_worker_instance_type": "m5.2xlarge",
+    "openshift_worker_instance_type": "m6i.2xlarge",
     "machineset_metadata_label_prefix": "machine.openshift.io",
-    "openshift_workload_node_instance_type": "m5.2xlarge"
+    "openshift_workload_node_instance_type": "m6i.2xlarge"
  }

--- a/dags/openshift_nightlies/config/install/rosa/iam-sdn.json
+++ b/dags/openshift_nightlies/config/install/rosa/iam-sdn.json
@@ -10,7 +10,7 @@
     "managed_ocp_version": "latest",
     "openshift_worker_count": 27,
     "openshift_network_type": "OpenShiftSDN",
-    "openshift_worker_instance_type": "m5.2xlarge",
+    "openshift_worker_instance_type": "m6i.2xlarge",
     "machineset_metadata_label_prefix": "machine.openshift.io",
-    "openshift_workload_node_instance_type": "m5.2xlarge"
+    "openshift_workload_node_instance_type": "m6i.2xlarge"
 }

--- a/dags/openshift_nightlies/config/install/rosa/ocm.json
+++ b/dags/openshift_nightlies/config/install/rosa/ocm.json
@@ -11,6 +11,6 @@
     "managed_ocp_version": "latest",
     "openshift_worker_count": 3,
     "openshift_network_type": "OpenShiftSDN",
-    "openshift_worker_instance_type": "m5.2xlarge",
+    "openshift_worker_instance_type": "m6i.2xlarge",
     "machineset_metadata_label_prefix": "machine.openshift.io"
 }

--- a/dags/openshift_nightlies/config/install/rosa/ovn-osd.json
+++ b/dags/openshift_nightlies/config/install/rosa/ovn-osd.json
@@ -10,7 +10,7 @@
     "managed_ocp_version": "latest",
     "openshift_worker_count": 27,
     "openshift_network_type": "OVNKubernetes",
-    "openshift_worker_instance_type": "m5.2xlarge",
+    "openshift_worker_instance_type": "m6i.2xlarge",
     "machineset_metadata_label_prefix": "machine.openshift.io",
-    "openshift_workload_node_instance_type": "m5.2xlarge"
+    "openshift_workload_node_instance_type": "m6i.2xlarge"
  }

--- a/dags/openshift_nightlies/config/install/rosa/ovn.json
+++ b/dags/openshift_nightlies/config/install/rosa/ovn.json
@@ -10,7 +10,7 @@
     "managed_ocp_version": "latest",
     "openshift_worker_count": 27,
     "openshift_network_type": "OVNKubernetes",
-    "openshift_worker_instance_type": "m5.2xlarge",
+    "openshift_worker_instance_type": "m6i.2xlarge",
     "machineset_metadata_label_prefix": "machine.openshift.io",
-    "openshift_workload_node_instance_type": "m5.2xlarge"
+    "openshift_workload_node_instance_type": "m6i.2xlarge"
 }

--- a/dags/openshift_nightlies/config/install/rosa/sdn.json
+++ b/dags/openshift_nightlies/config/install/rosa/sdn.json
@@ -10,7 +10,7 @@
     "managed_ocp_version": "latest",
     "openshift_worker_count": 27,
     "openshift_network_type": "OpenShiftSDN",
-    "openshift_worker_instance_type": "m5.2xlarge",
+    "openshift_worker_instance_type": "m6i.2xlarge",
     "machineset_metadata_label_prefix": "machine.openshift.io",
-    "openshift_workload_node_instance_type": "m5.2xlarge"
+    "openshift_workload_node_instance_type": "m6i.2xlarge"
 }

--- a/dags/openshift_nightlies/config/install/rosa/upgrade.json
+++ b/dags/openshift_nightlies/config/install/rosa/upgrade.json
@@ -10,7 +10,7 @@
     "managed_ocp_version": "prelatest",
     "openshift_worker_count": 24,
     "openshift_network_type": "OVNKubernetes",
-    "openshift_worker_instance_type": "m5.2xlarge",
+    "openshift_worker_instance_type": "m6i.2xlarge",
     "machineset_metadata_label_prefix": "machine.openshift.io",
-    "openshift_workload_node_instance_type": "m5.2xlarge"
+    "openshift_workload_node_instance_type": "m6i.2xlarge"
 }


### PR DESCRIPTION
m6i instances have better performance/price and they now
seem to be enabled in ROSA for the regions we care about.
Leaving HyperShift at m5 instances and we can revisit based
on direction from HyperShift team.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
