### PR TITLE
Use default CNI

### DIFF
--- a/dags/openshift_nightlies/config/install/alibaba/acs.json
+++ b/dags/openshift_nightlies/config/install/alibaba/acs.json
@@ -9,7 +9,6 @@
     "openshift_worker_count": 3,
     "openshift_base_domain": "alicloud-qe.devcluster.openshift.com",
     "openshift_host_prefix": "22",
-    "openshift_network_type": "OpenShiftSDN",
     "openshift_debug_config": false,
     "openshift_master_instance_type": "ecs.r5.4xlarge",
     "openshift_worker_instance_type": "ecs.g6.2xlarge",

--- a/dags/openshift_nightlies/config/install/aws/acs.json
+++ b/dags/openshift_nightlies/config/install/aws/acs.json
@@ -7,7 +7,6 @@
     "openshift_master_count": 3,
     "openshift_worker_count": 3,
     "openshift_host_prefix": "22",
-    "openshift_network_type": "OpenShiftSDN",
     "openshift_master_instance_type": "r5.4xlarge",
     "openshift_worker_instance_type": "m5.2xlarge",
     "openshift_master_root_volume_size": 220,

--- a/dags/openshift_nightlies/config/install/azure/acs.json
+++ b/dags/openshift_nightlies/config/install/azure/acs.json
@@ -3,7 +3,6 @@
     "openshift_worker_count": 3,
     "openshift_base_domain": "ats.azure.devcluster.openshift.com",
     "openshift_host_prefix": "23",
-    "openshift_network_type": "OpenShiftSDN",
     "openshift_master_vm_size": "Standard_E16s_v3",
     "openshift_worker_vm_size": "Standard_D8s_v3",
     "openshift_master_root_volume_size": 256,

--- a/dags/openshift_nightlies/config/install/gcp/acs.json
+++ b/dags/openshift_nightlies/config/install/gcp/acs.json
@@ -3,7 +3,6 @@
     "openshift_worker_count": 3,
     "openshift_base_domain": "perfscale.gcp.devcluster.openshift.com",
     "openshift_host_prefix": "23",
-    "openshift_network_type": "OpenShiftSDN",
     "openshift_master_instance_type": "n2-highmem-16",
     "openshift_worker_instance_type": "n1-standard-8",
     "openshift_master_root_volume_size": 220,


### PR DESCRIPTION
We should accept the default CNI for OpenShift for ACS.

Signed-off-by: Joe Talerico (rook) <joe.talerico@gmail.com>

### Description

### Fixes
