### PR TITLE
Add dags for loading the chaos test clusters for HyperShift

### DIFF
--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p75.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p75.json
@@ -1,0 +1,25 @@
+{
+    "benchmarks": [
+        {
+            "name": "cluster-density-ms-p75",
+            "workload": "kube-burner",
+            "trigger_rule": "all_done",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "cluster-density-ms",
+                "JOB_ITERATIONS": "75",
+                "JOB_TIMEOUT": "18000",
+                "STEP_SIZE": "2m",
+                "HYPERSHIFT": "true",
+                "METRICS_PROFILE": "metrics-profiles/hypershift-metrics.yaml",
+                "QPS": "20",
+                "BURST": "20",
+                "LOG_LEVEL": "info",
+                "PLATFORM_ALERTS": "false",
+                "CLEANUP_WHEN_FINISH": "false",
+                "CLEANUP": "true",
+                "MUST_GATHER_EACH_TASK": "false"
+            }
+        }
+    ]
+}

--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p90.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p90.json
@@ -1,0 +1,25 @@
+{
+    "benchmarks": [
+        {
+            "name": "cluster-density-ms-p90",
+            "workload": "kube-burner",
+            "trigger_rule": "all_done",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "cluster-density-ms",
+                "JOB_ITERATIONS": "100",
+                "JOB_TIMEOUT": "18000",
+                "STEP_SIZE": "2m",
+                "HYPERSHIFT": "true",
+                "METRICS_PROFILE": "metrics-profiles/hypershift-metrics.yaml",
+                "QPS": "20",
+                "BURST": "20",
+                "LOG_LEVEL": "info",
+                "PLATFORM_ALERTS": "false",
+                "CLEANUP_WHEN_FINISH": "false",
+                "CLEANUP": "true",
+                "MUST_GATHER_EACH_TASK": "false"
+            }
+        }
+    ]
+}

--- a/dags/openshift_nightlies/config/install/hypershift/ovn-p75.json
+++ b/dags/openshift_nightlies/config/install/hypershift/ovn-p75.json
@@ -8,7 +8,7 @@
     "openshift_worker_count": 3,
     "openshift_network_type": "OVNKubernetes",
     "openshift_worker_instance_type": "m5.4xlarge",
-    "number_of_hosted_cluster": 1,
+    "number_of_hosted_cluster": 3,
     "hypershift_operator_image": "quay.io/hypershift/hypershift-operator:4.11",
     "hosted_cluster_nodepool_size": 7,
     "hosted_cluster_instance_type": "m5.2xlarge",

--- a/dags/openshift_nightlies/config/install/hypershift/ovn-p90.json
+++ b/dags/openshift_nightlies/config/install/hypershift/ovn-p90.json
@@ -8,7 +8,7 @@
     "openshift_worker_count": 3,
     "openshift_network_type": "OVNKubernetes",
     "openshift_worker_instance_type": "m5.4xlarge",
-    "number_of_hosted_cluster": 1,
+    "number_of_hosted_cluster": 3,
     "hypershift_operator_image": "quay.io/hypershift/hypershift-operator:4.11",
     "hosted_cluster_nodepool_size": 10,
     "hosted_cluster_instance_type": "m5.2xlarge",

--- a/dags/openshift_nightlies/manifest.yaml
+++ b/dags/openshift_nightlies/manifest.yaml
@@ -183,7 +183,7 @@ platforms:
           benchmarks: data-plane.json
 
   hypershift:
-    versions: ["4.10", "4.11"]
+    versions: ["4.11"]
     variants:
       - name: sdn-control-plane
         schedule:  "30 2 * * 1,3,5" # an hour gap for OSD to avoid OsdCcsAdmin key limit
@@ -205,6 +205,14 @@ platforms:
         config:
           install: hypershift/ovn-p90.json
           benchmarks: hosted-control-plane-p90.json          
+      - name: chaos-ovn-control-plane-p75
+        config:
+          install: hypershift/ovn-p75.json
+          benchmarks: hosted-control-plane-chaos-p75.json
+      - name: chaos-ovn-control-plane-p90
+        config:
+          install: hypershift/ovn-p90.json
+          benchmarks: hosted-control-plane-chaos-p90.json
 
   prebuilt:
     versions: ["4.x"]

--- a/dags/openshift_nightlies/scripts/install/hypershift.sh
+++ b/dags/openshift_nightlies/scripts/install/hypershift.sh
@@ -112,7 +112,7 @@ install(){
     aws s3api create-bucket --acl public-read --bucket $MGMT_CLUSTER_NAME-aws-rhperfscale-org --create-bucket-configuration LocationConstraint=$AWS_REGION --region $AWS_REGION || true
     echo "Wait till S3 bucket is ready.."
     aws s3api wait bucket-exists --bucket $MGMT_CLUSTER_NAME-aws-rhperfscale-org 
-    hypershift install $HO_IMAGE_ARG  --oidc-storage-provider-s3-bucket-name $MGMT_CLUSTER_NAME-aws-rhperfscale-org --oidc-storage-provider-s3-credentials aws_credentials --oidc-storage-provider-s3-region $AWS_REGION  --enable-ocp-cluster-monitoring --metrics-set=All
+    hypershift install $HO_IMAGE_ARG  --oidc-storage-provider-s3-bucket-name $MGMT_CLUSTER_NAME-aws-rhperfscale-org --oidc-storage-provider-s3-credentials aws_credentials --oidc-storage-provider-s3-region $AWS_REGION  --platform-monitoring All --metrics-set All
     echo "Wait till Operator is ready.."
     kubectl wait --for=condition=available --timeout=600s deployments/operator -n hypershift
 }


### PR DESCRIPTION
### Description
This commit:
- Adds install and workload configs with cleanup set to
   false to be able to run the chaos tests post install and load.
- Disables 4.10 dags for HyperShift.
