### PR TITLE
Perf CI - Populate `use` tag so we can account for cloud spend better

### DIFF
--- a/dags/openshift_nightlies/scripts/install/cloud.sh
+++ b/dags/openshift_nightlies/scripts/install/cloud.sh
@@ -16,7 +16,7 @@ done
 setup(){
     mkdir /home/airflow/workspace
     cd /home/airflow/workspace
-    git clone --depth=1 --single-branch --branch master https://github.com/cloud-bulldozer/scale-ci-deploy
+    git clone --depth=1 --single-branch --branch tag_resources https://github.com/jtaleric/scale-ci-deploy
     git clone --depth=1 --single-branch --branch master https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
     export PUBLIC_KEY=/home/airflow/workspace/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
     export PRIVATE_KEY=/home/airflow/workspace/perf-dept/ssh_keys/id_rsa_pbench_ec2 

--- a/dags/openshift_nightlies/scripts/install/cloud.sh
+++ b/dags/openshift_nightlies/scripts/install/cloud.sh
@@ -16,7 +16,7 @@ done
 setup(){
     mkdir /home/airflow/workspace
     cd /home/airflow/workspace
-    git clone --depth=1 --single-branch --branch tag_resources https://github.com/jtaleric/scale-ci-deploy
+    git clone --depth=1 --single-branch --branch master https://github.com/cloud-bulldozer/scale-ci-deploy
     git clone --depth=1 --single-branch --branch master https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
     export PUBLIC_KEY=/home/airflow/workspace/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
     export PRIVATE_KEY=/home/airflow/workspace/perf-dept/ssh_keys/id_rsa_pbench_ec2 

--- a/dags/openshift_nightlies/tasks/install/cloud/defaults.json
+++ b/dags/openshift_nightlies/tasks/install/cloud/defaults.json
@@ -2,6 +2,7 @@
     "orchestration_user": "",
     "orchestration_host": "",
     "sshkey_token": "",
+    "cluster_owner": "",
     "openshift_client_location": "",
     "openshift_base_domain": "perfscale.devcluster.openshift.com",
     "openshift_cluster_name": "",

--- a/dags/openshift_nightlies/tasks/install/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/openshift.py
@@ -83,6 +83,7 @@ class AbstractOpenshiftInstaller(ABC):
         self.config = {**self.config,
                        ** self._get_playbook_operations(operation)}
         self.config['openshift_cluster_name'] = self.cluster_name
+        self.config['cluster_owner'] = self.cluster_name.split("-")[0]
         self.config['dynamic_deploy_path'] = f"{self.config['openshift_cluster_name']}"
         self.config['kubeconfig_path'] = f"/root/{self.config['dynamic_deploy_path']}/auth/kubeconfig"
         self.env = {


### PR DESCRIPTION
### Description
This will populate a tag `use` with the github-id of the user deploying an Airflow instance. 

### Need-to-do
Once this is merged we will need all current dags to be updated. 