### PR TITLE
Update ocm-api-load to use --log-file

### DIFF
--- a/dags/nocp/scripts/run_ocm_benchmark.sh
+++ b/dags/nocp/scripts/run_ocm_benchmark.sh
@@ -59,7 +59,7 @@ run_ocm_benchmark(){
 
     start_time=\$(date +%s)
     echo "Running the ocm-load-test test"
-    build/ocm-load-test --config-file config.yaml &> ${UUID}_ocm-load-test
+    build/ocm-load-test --config-file config.yaml --log-file ${UUID}_ocm-load-test
     cp ${UUID}_ocm-load-test /tmp/${UUID}/results/${UUID}_ocm-load-test.json
 
     end_time=\$(date +%s)


### PR DESCRIPTION
### Description

Utilize the log-file option instead of redirecting to a file. This allows errors to still bubble up to the surface but keeps noise low.

### Fixes
