### PR TITLE
added hc nodepool multi az arg

### DIFF
--- a/dags/openshift_nightlies/tasks/install/hypershift/defaults.json
+++ b/dags/openshift_nightlies/tasks/install/hypershift/defaults.json
@@ -46,5 +46,6 @@
     "hypershift_cli_version": "container",
     "hypershift_operator_image": "",
     "hcp_platform_monitoring": "",
-    "hc_install_interval": 0
+    "hc_install_interval": 0,
+    "hc_multi_az": true
 }


### PR DESCRIPTION
### Description
Hypershift hostedclusters nodepool assignments are single zone by default, now adding an option to select multi az option and passing it to CLI arguments. 

##### Hypershift CLI
```
--zones strings       The availability zones in which NodePools will be created
```

### Fixes
