### PR TITLE
fix ocm ci schedule

### DIFF
--- a/dags/nocp/manifest.yaml
+++ b/dags/nocp/manifest.yaml
@@ -3,7 +3,7 @@ dagConfig:
     enabled: true
     default: "0 12 * * 1,3,5"
     nocp:
-      ocm: "0 0 * * 5"
+      ocm: "0 10 * * 3"
   cleanupOnSuccess: true
   executorImages:
     repository: quay.io/cloud-bulldozer


### PR DESCRIPTION
Dag run is successful when triggered manually and failing only when auto scheduled. I got succesful run in my playground with these changes, so pushing a PR to run on airflow playground.

More details about this issue -
https://github.com/cloud-bulldozer/airflow-kubernetes/issues/253

### Description

### Fixes
