### PR TITLE
Fix aws keys

### DIFF
--- a/dags/nocp/config/benchmarks/ocm.json
+++ b/dags/nocp/config/benchmarks/ocm.json
@@ -31,6 +31,12 @@
 		"SELF_TERMS_DURATION": "10",
 		"CERTIFICATES_RATE": "15/s",
 		"CERTIFICATES_DURATION": "10",
+		"CREATE_SERVICES_RATE": "1/m",
+		"CREATE_SERVICES_DURATION": "1",
+		"GET_SERVICES_RATE": "1/m",
+		"GET_SERVICES_DURATION": "1",
+		"PATCH_SERVICES_RATE": "1/m",
+		"PATCH_SERVICES_DURATION": "1",
 		"KUBE_BURNER_RELEASE_URL": "https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16.1/kube-burner-0.16.1-Linux-x86_64.tar.gz",
 		"PROM_URL": "https://prometheus.app-sre-stage-01.devshift.net"
             }

--- a/dags/nocp/scripts/run_ocm_benchmark.sh
+++ b/dags/nocp/scripts/run_ocm_benchmark.sh
@@ -26,7 +26,7 @@ run_ocm_benchmark(){
     echo "Cleanup previous UUIDs"
     rm -rf /tmp/*api-load*
     mkdir /tmp/${UUID}
-    git clone --single-branch --branch ci_test https://github.com/venkataanil/ocm-api-load /tmp/${UUID}
+    git clone https://github.com/cloud-bulldozer/ocm-api-load /tmp/${UUID}
     cd /tmp/${UUID}
     echo "Building the binary"
     go mod download

--- a/dags/nocp/scripts/run_ocm_benchmark.sh
+++ b/dags/nocp/scripts/run_ocm_benchmark.sh
@@ -39,10 +39,10 @@ run_ocm_benchmark(){
     rm -rf /tmp/environment_new.txt vars.sh
 
     echo "Clean-up existing OSD access keys.."
-    AWS_KEY=$(aws iam list-access-keys --user-name OsdCcsAdmin --output text --query 'AccessKeyMetadata[*].AccessKeyId')
-    LEN_AWS_KEY=`echo $AWS_KEY | wc -w`
-    if [[  ${LEN_AWS_KEY} -eq 2 ]]; then
-        aws iam delete-access-key --user-name OsdCcsAdmin --access-key-id `printf ${AWS_KEY[0]}`
+    AWS_KEY=\$(/usr/bin/aws iam list-access-keys --user-name OsdCcsAdmin --output text --query 'AccessKeyMetadata[*].AccessKeyId')
+    LEN_AWS_KEY=\$(echo \$AWS_KEY | wc -w)
+    if [[  \${LEN_AWS_KEY} -eq 2 ]]; then
+	/usr/bin/aws iam delete-access-key --user-name OsdCcsAdmin --access-key-id \$(printf \${AWS_KEY[0]})
     fi
     echo "Creating aws key with admin user for OCM testing"
     admin_key=\$(/usr/bin/aws iam create-access-key --user-name OsdCcsAdmin --output json)


### PR DESCRIPTION
### Description
    Use ocm-api-load from master instead of branch.     
    Pass rate and duration values for newly added endpoints i.e use merged PR https://github.com/cloud-bulldozer/ocm-api-load/pull/90
    

    ocm: append '\' before shell command output
    
    OCM CI failing with the errors described in
    https://github.com/cloud-bulldozer/airflow-kubernetes/issues/268
    
    Recently PR #255 introduced some code for identifying last active
    AWS key which is causing errors in CI run.
    Inside run_ocm_benchmark.sh, the script ssh into ocm CI jumphost
    and execute this code. So we need to add additional '\' before
    parsing/using command output.


### Fixes
     https://github.com/cloud-bulldozer/airflow-kubernetes/issues/268
