### PR TITLE
hypershift mgmt kubeconfig for router-perf

### DIFF
--- a/dags/openshift_nightlies/scripts/install/hypershift.sh
+++ b/dags/openshift_nightlies/scripts/install/hypershift.sh
@@ -288,10 +288,10 @@ cleanup(){
 }
 
 export INSTALL_METHOD=$(cat ${json_file} | jq -r .cluster_install_method)
-setup
 export HC_INTERVAL=$(cat ${json_file} | jq -r .hc_install_interval)
 SKEW_FACTOR=$(echo $HOSTED_NAME|awk -F- '{print$2}')
 sleep $(($HC_INTERVAL*$SKEW_FACTOR))
+setup
 echo "Set start time of prom scrape"
 export START_TIME=$(date +"%s")
 

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -ex
-
 while getopts w:c: flag
 do
     case "${flag}" in

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 while getopts w:c: flag
 do
     case "${flag}" in
@@ -27,6 +29,12 @@ setup(){
 
     if [[ ! -z "$KUBEADMIN_PASSWORD" ]] && [[ $PLATFORM == "aro" ]]; then
         oc login -u kubeadmin -p $KUBEADMIN_PASSWORD --insecure-skip-tls-verify
+    fi
+    if [[ ! -z $MGMT_KUBECONFIG_SECRET ]]; then
+        unset KUBECONFIG # Unsetting Hostedcluster kubeconfig, will fall back to Airflow cluster kubeconfig
+        kubectl get secret $MGMT_KUBECONFIG_SECRET -o json | jq -r '.data.config' | base64 -d > /home/airflow/workspace/mgmt_kubeconfig
+        export HYPERSHIFT_MANAGEMENT_KUBECONFIG="/home/airflow/workspace/mgmt_kubeconfig"
+        export KUBECONFIG=/home/airflow/workspace/config
     fi
 }
 

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -83,7 +83,9 @@ class E2EBenchmarks():
                 "THANOS_RECEIVER_URL": var_loader.get_secret("thanos_receiver_url"),
                 "PROM_URL": var_loader.get_secret("thanos_querier_url"),
                 "MGMT_CLUSTER_NAME": f"{mgmt_cluster_name}.*",
-                "HOSTED_CLUSTER_NS": f"clusters-hypershift-{mgmt_cluster_name}-{self.task_group}"
+                "HOSTED_CLUSTER_NS": f"clusters-hyp-{mgmt_cluster_name}-{self.task_group}",
+                "MGMT_KUBECONFIG_SECRET": f"{release.get_release_name()}-kubeconfig",
+                **self._insert_kube_env()
             }
 
     def get_benchmarks(self):
@@ -137,3 +139,8 @@ class E2EBenchmarks():
 
         self._add_indexer(task)
         return task
+
+    # This Helper Injects Airflow environment variables into the task execution runtime
+    # This allows the task to interface with the Kubernetes cluster Airflow is hosted on.
+    def _insert_kube_env(self):
+        return {key: value for (key, value) in environ.items() if "KUBERNETES" in key}


### PR DESCRIPTION
### Description
e2e-benchmarking router-perf script requires Hypershift Management Cluster access to modify default ingress and cluster version operator components when needed, passing env var to it.
Ref - https://github.com/cloud-bulldozer/e2e-benchmarking/pull/495 

### Fixes
