### PR TITLE
ocm: display metrics dashboard urls

### DIFF
--- a/dags/nocp/scripts/run_ocm_api_load.sh
+++ b/dags/nocp/scripts/run_ocm_api_load.sh
@@ -57,6 +57,14 @@ run_ocm_api_load(){
 
     echo "Removing configuration files"
     rm -f config.yaml kube-burner-am-config.yaml kube-burner-cs-config.yaml
+
+    echo "converting start and end times into milliseconds"
+    start_time=`expr $start_time \* 1000`
+    end_time=`expr $end_time \* 1000`
+
+    echo "Results URLs"
+    echo "Account Manager Dashboard https://grafana.apps.observability.perfscale.devcluster.openshift.com/d/uhc-account-manager/uhc-account-manager?orgId=1&var-uuid=${UUID}&var-datasource=ocm-uhc-acct-mngr&from=$start_time&to=$end_time"
+    echo "Clusters Service Dashboard https://grafana.apps.observability.perfscale.devcluster.openshift.com/d/uhc-clusters-service/uhc-clusters-service?orgId=1&var-datasource=ocm-uhc-clusters-service&var-uuid=${UUID}&from=$start_time&to=$end_time"
 }
 
 run_ocm_api_load


### PR DESCRIPTION
Earlier airflow test run log was showing metrics dashboard urls which was removed in previous PR [1], now adding it back.

[1] https://github.com/cloud-bulldozer/airflow-kubernetes/pull/271


