### PR TITLE
ocm: avoid overriding local shell variables

### DIFF
--- a/dags/nocp/scripts/run_ocm_api_load.sh
+++ b/dags/nocp/scripts/run_ocm_api_load.sh
@@ -5,7 +5,14 @@ set -x
 run_ocm_api_load(){
     echo "Cleanup previous UUIDs"
     cd ~/
-    export $(cat environment.txt | xargs)
+    # Export environment variables provided by airflow, however don't override local shell variables like PWD
+    env > /tmp/local_env.txt
+    while IFS="=" read -r key value; do
+        if ! grep -q "$key=" /tmp/local_env.txt; then
+                export $key=$value
+        fi
+    done < environment.txt
+
     export UUID=$(uuidgen | head -c8)-$AIRFLOW_CTX_TASK_ID-$(date '+%Y%m%d')
     echo "# Benchmark UUID: ${UUID}"
     rm -rf ocm-api-load


### PR DESCRIPTION
This commit avoids overriding local shell variables (like PWD) in the ORCHESTRATION_HOST while exporting environment variables provided by airflow.

Currently airflow task is failing with below error [2022-11-25, 04:00:23 EST] {subprocess.py:92} INFO - + make [2022-11-25, 04:00:23 EST] {subprocess.py:92} INFO - make: getcwd: No such file or directory

as we are overriding "PWD=/home/stack" in ORCHESTRATION_HOST with "PWD=/tmp/airflowtmpnobuqrcl" which is provided by airflow.

CI failure link http://airflow.apps.sailplane.perf.lab.eng.rdu2.redhat.com/log?dag_id=ocm&task_id=api-load&execution_date=2022-11-24T09%3A00%3A00%2B00%3A00