### PR TITLE
OSP update the storage class name as per 4.12

### DIFF
--- a/dags/openshift_nightlies/config/install/openstack/kuryr.json
+++ b/dags/openshift_nightlies/config/install/openstack/kuryr.json
@@ -50,9 +50,9 @@
     "openshift_workload_node_volume_type": "",
     "openshift_workload_node_volume_iops": "0",
     "openshift_prometheus_retention_period": "15d",
-    "openshift_prometheus_storage_class": "standard",
+    "openshift_prometheus_storage_class": "standard-csi",
     "openshift_prometheus_storage_size": "25Gi",
-    "openshift_alertmanager_storage_class": "standard",
+    "openshift_alertmanager_storage_class": "standard-csi",
     "openshift_alertmanager_storage_size": "5Gi",
     "openshift_toggle_workload_node": "false",
     "job_iterations": "1"

--- a/dags/openshift_nightlies/config/install/openstack/ovnk.json
+++ b/dags/openshift_nightlies/config/install/openstack/ovnk.json
@@ -50,9 +50,9 @@
     "openshift_workload_node_volume_type": "",
     "openshift_workload_node_volume_iops": "0",
     "openshift_prometheus_retention_period": "15d",
-    "openshift_prometheus_storage_class": "standard",
+    "openshift_prometheus_storage_class": "standard-csi",
     "openshift_prometheus_storage_size": "25Gi",
-    "openshift_alertmanager_storage_class": "standard",
+    "openshift_alertmanager_storage_class": "standard-csi",
     "openshift_alertmanager_storage_size": "5Gi",
     "openshift_toggle_workload_node": "false",
     "job_iterations": "1"

--- a/dags/openshift_nightlies/config/install/openstack/sdn.json
+++ b/dags/openshift_nightlies/config/install/openstack/sdn.json
@@ -50,9 +50,9 @@
     "openshift_workload_node_volume_type": "",
     "openshift_workload_node_volume_iops": "0",
     "openshift_prometheus_retention_period": "15d",
-    "openshift_prometheus_storage_class": "standard",
+    "openshift_prometheus_storage_class": "standard-csi",
     "openshift_prometheus_storage_size": "25Gi",
-    "openshift_alertmanager_storage_class": "standard",
+    "openshift_alertmanager_storage_class": "standard-csi",
     "openshift_alertmanager_storage_size": "5Gi",
     "openshift_toggle_workload_node": "false",
     "job_iterations": "1"


### PR DESCRIPTION
### Description
The default storage class name is changed from standard to standard-csi from 4.12, updating the same in the var file
### Fixes
