### PR TITLE
hypershift: corrected prefix of hostedcluster

### DIFF
--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -83,7 +83,7 @@ class E2EBenchmarks():
                 "THANOS_RECEIVER_URL": var_loader.get_secret("thanos_receiver_url"),
                 "PROM_URL": var_loader.get_secret("thanos_querier_url"),
                 "MGMT_CLUSTER_NAME": f"{mgmt_cluster_name}.*",
-                "HOSTED_CLUSTER_NS": f"clusters-hyp-{mgmt_cluster_name}-{self.task_group}",
+                "HOSTED_CLUSTER_NS": f"clusters-hcp-{mgmt_cluster_name}-{self.task_group}",
                 "MGMT_KUBECONFIG_SECRET": f"{release.get_release_name()}-kubeconfig",
                 **self._insert_kube_env()
             }


### PR DESCRIPTION
### Description
The workload env var isn't matching the right hostedcluster name [here](https://github.com/cloud-bulldozer/airflow-kubernetes/blob/master/dags/openshift_nightlies/scripts/install/hypershift.sh#L50)

### Fixes
