### PR TITLE
Fix CI

### DIFF
--- a/dags/setup.cfg
+++ b/dags/setup.cfg
@@ -22,23 +22,22 @@ packages = find:
 include_package_data = True
 # Add here dependencies of your project (semicolon/line-separated), e.g.
 install_requires =
-    kubernetes
-    apache-airflow
-    prometheus-api-client
-    elasticsearch
-    apache-airflow-providers-slack
-    markupsafe==2.0.1
+  kubernetes>=25.0.0
+  apache-airflow==2.3.2
+  prometheus-api-client==0.5.2
+  elasticsearch==7.13.4
+  apache-airflow-providers-slack==7.1.0
+  markupsafe==2.0.1
+
 python_requires = >=3.8
 
 [options.extras_require]
 tests =
     pytest
     pytest-cov
-    tox
     pytest-mock
     pytest-env
     requests-mock
-    pytest
 [aliases]
 dists = bdist_wheel
 

--- a/dags/tox.ini
+++ b/dags/tox.ini
@@ -8,15 +8,15 @@ extras =
     tests
 setenv =
     py{38,39}-unit: COVERAGE_FILE = .coverage.{envname}
-deps = 
-    requests-mock
-    pytest
-    kubernetes
-    apache-airflow
-    pytest-mock
-    pytest-env
-    prometheus-api-client
-    elasticsearch
+deps =
+    kubernetes>=25.0.0
+    apache-airflow==2.3.2
+    prometheus-api-client==0.5.2
+    elasticsearch==7.13.4
+    apache-airflow-providers-slack==7.1.0
+    markupsafe==2.0.1
+
+python_requires = >=3.8
 
 commands =
     python -m pytest --cov-config=.coveragerc --cov=openshift_nightlies --cov-report term-missing {posargs}


### PR DESCRIPTION
### Description

New pip versions do a lot of backtracking, that could lead to extremely long dependency resolution, specially when there's a very complex dependency such as the kubernetes SDK.
To avoid so let's use fixed versions of the dependencies as suggested at the official docs
https://pip.pypa.io/en/stable/topics/dependency-resolution/#reduce-the-number-of-versions-pip-is-trying-to-use

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>


