### PR TITLE
Wait form workload nodes only when configured

### DIFF
--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -374,7 +374,9 @@ if [[ "$operation" == "install" ]]; then
         printf "INFO: Cluster not found, installing..."
         install
         index_metadata
-        _wait_for_workload_nodes_ready ${CLUSTER_NAME}
+        if [[ $WORKLOAD_TYPE != "null" ]]; then
+          _wait_for_workload_nodes_ready ${CLUSTER_NAME}
+        fi
     elif [ "${CLUSTER_STATUS}" == "ready" ] ; then
         printf "INFO: Cluster ${CLUSTER_NAME} already installed and ready, reusing..."
 	    postinstall


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Airflow crashes when there's no workload nodes expected since it always tries to wait for them to show up. A conditional is missing to fix it.

### Fixes
