### PR TITLE
Removing bad reference for gsheet key

### DIFF
--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -19,7 +19,6 @@ setup(){
     cd /home/airflow/workspace
     cp /home/airflow/auth/config /home/airflow/workspace/config
     export KUBECONFIG=/home/airflow/workspace/config
-    curl -sS http://dell-r510-01.perf.lab.eng.rdu2.redhat.com/msheth/gsheet_key.json -o /tmp/key.json
     export GSHEET_KEY_LOCATION=/tmp/key.json
     export RUN_ID=${AIRFLOW_CTX_DAG_ID}/${AIRFLOW_CTX_DAG_RUN_ID}/$AIRFLOW_CTX_TASK_ID
     export SNAPPY_RUN_ID=${AIRFLOW_CTX_DAG_ID}/${AIRFLOW_CTX_DAG_RUN_ID}

--- a/dags/openshift_nightlies/tasks/benchmarks/e2e.py
+++ b/dags/openshift_nightlies/tasks/benchmarks/e2e.py
@@ -25,6 +25,13 @@ class E2EBenchmarks():
         self.dag_config = config
         self.snappy_creds = var_loader.get_secret("snappy_creds", deserialize_json=True)
         self.es_server_baseline = var_loader.get_secret("es_server_baseline")
+        self.gsheet = var_loader.get_secret("gsheet_key")
+
+        # Write gsheet data to /tmp/key.json
+        if len(self.gsheet) > 1 :
+            f = open("/tmp/key.json","w")
+            f.write(json.dumps(self.gsheet))
+            f.close()
 
         # Specific Task Configuration
         self.vars = var_loader.build_task_vars(
@@ -38,6 +45,7 @@ class E2EBenchmarks():
             "PLATFORM": self.release.platform,
             "TASK_GROUP": self.task_group,
             "ES_SERVER_BASELINE": self.es_server_baseline
+
         }
         self.env.update(self.dag_config.dependencies)
 


### PR DESCRIPTION
- Removing curl to server which is gone
- Moving gsheet key to vault
- Pulling from vault and storing key in same `/tmp/key.json`

Signed-off-by: Joe Talerico <jtaleric@redhat.com>
