### PR TITLE
Fix ROSA deployment

### DIFF
--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -226,11 +226,6 @@ setup(){
             export ROSA_VERSION=$(rosa list versions -o json --channel-group=${MANAGED_CHANNEL_GROUP} | jq -r '.[] | select(.raw_id|startswith('\"${version}\"')) | .raw_id' | grep ^${MANAGED_OCP_VERSION}$)
         fi
         [ -z "${ROSA_VERSION}" ] && echo "ERROR: Image not found for version (${version}) on ROSA ${MANAGED_CHANNEL_GROUP} channel group" && exit 1
-        if [ "${MANAGED_CHANNEL_GROUP}" == "nightly" ] ; then
-            ROSA_VERSION="${ROSA_VERSION}-nightly"
-        elif [ "${MANAGED_CHANNEL_GROUP}" == "candidate" ] ; then
-            ROSA_VERSION="${ROSA_VERSION}-candidate"
-        fi
         return 0
     fi
 }
@@ -252,7 +247,7 @@ install(){
         if [ $AWS_AUTHENTICATION_METHOD == "sts" ] ; then
             INSTALLATION_PARAMS="${INSTALLATION_PARAMS} --sts -m auto --yes"
         fi
-        rosa create cluster --tags=User:${GITHUB_USERNAME} --cluster-name ${CLUSTER_NAME} --version "${ROSA_VERSION}" --channel-group=${MANAGED_CHANNEL_GROUP} --multi-az --compute-machine-type ${COMPUTE_WORKERS_TYPE} --compute-nodes ${COMPUTE_WORKERS_NUMBER} --network-type ${NETWORK_TYPE} ${INSTALLATION_PARAMS}
+        rosa create cluster --tags=User:${GITHUB_USERNAME} --cluster-name ${CLUSTER_NAME} --version "${ROSA_VERSION}" --channel-group=${MANAGED_CHANNEL_GROUP} --multi-az --compute-machine-type ${COMPUTE_WORKERS_TYPE} --replicas=${COMPUTE_WORKERS_NUMBER} --network-type ${NETWORK_TYPE} ${INSTALLATION_PARAMS}
     fi
     _wait_for_cluster_ready ${CLUSTER_NAME}
     postinstall


### PR DESCRIPTION
Newest binary doesn't need the -candidate or -nightly suffixes Also fixes:

```
[2023-02-02, 10:51:20 UTC] {subprocess.py:92} INFO - + rosa create
cluster --tags=User:rsevilla87 --cluster-name perf-412-f4c9 --version 4.12.0-0.nightly-2023-02-01-230633-nightly --channel-group=nightly  --multi-az --compute-machine-type m5.2xlarge --compute-nodes 24  --network-type OVNKubernetes --sts -m auto --yes
[2023-02-02, 10:51:20 UTC] {subprocess.py:92} INFO - Flag  --compute-nodes has been deprecated, use --replicas instead
```

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>
