### PR TITLE
updated workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,12 @@
 name: Release Airflow Images
 on:
+  schedule:  # triggers every midnight
+    - cron: '0 0 * * *' 
   push:
     branches:
       - master
     tags:
-      - "*" # triggers only if push new tag version
+      - "*" # triggers on a push event
 
 jobs:
   containers:


### PR DESCRIPTION
### Description
To trigger a rebuild of airflow-images every night, to keep the CLIs up to date.

In ROSA build, we often get failures due to CLIs since they do frequent changes in the code, its better to keep the CLI up to date.

### Fixes
