### PR TITLE
Updated least worker size for all jobs

### DIFF
--- a/dags/openshift_nightlies/config/install/alibaba/acs.json
+++ b/dags/openshift_nightlies/config/install/alibaba/acs.json
@@ -6,7 +6,7 @@
     "alibaba_resource_group_id": "",
     "aliyun_binary": "https://aliyuncli.alicdn.com/aliyun-cli-linux-3.0.32-amd64.tgz",
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 6,
     "openshift_base_domain": "alicloud-qe.devcluster.openshift.com",
     "openshift_host_prefix": "22",
     "openshift_debug_config": false,

--- a/dags/openshift_nightlies/config/install/alibaba/ovn-dp.json
+++ b/dags/openshift_nightlies/config/install/alibaba/ovn-dp.json
@@ -6,7 +6,7 @@
     "alibaba_resource_group_id": "",
     "aliyun_binary": "https://aliyuncli.alicdn.com/aliyun-cli-linux-3.0.32-amd64.tgz",
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 6,
     "openshift_base_domain": "alicloud-qe.devcluster.openshift.com",
     "openshift_host_prefix": "22",
     "openshift_network_type": "OVNKubernetes",

--- a/dags/openshift_nightlies/config/install/alibaba/sdn-dp.json
+++ b/dags/openshift_nightlies/config/install/alibaba/sdn-dp.json
@@ -6,7 +6,7 @@
     "alibaba_resource_group_id": "",
     "aliyun_binary": "https://aliyuncli.alicdn.com/aliyun-cli-linux-3.0.32-amd64.tgz",
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 6,
     "openshift_base_domain": "alicloud-qe.devcluster.openshift.com",
     "openshift_host_prefix": "22",
     "openshift_network_type": "OpenShiftSDN",

--- a/dags/openshift_nightlies/config/install/aws-arm/ovn-dp.json
+++ b/dags/openshift_nightlies/config/install/aws-arm/ovn-dp.json
@@ -4,7 +4,7 @@
     "aws_access_key_id": "",
     "aws_secret_access_key": "",
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 6,
     "openshift_host_prefix": "22",
     "openshift_network_type": "OVNKubernetes",
     "openshift_master_instance_type": "m6g.2xlarge",

--- a/dags/openshift_nightlies/config/install/aws/acs.json
+++ b/dags/openshift_nightlies/config/install/aws/acs.json
@@ -2,7 +2,7 @@
     "openshift_client_location": "",
     "openshift_install_binary_url": "",
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 6,
     "openshift_host_prefix": "22",
     "openshift_master_instance_type": "r5.4xlarge",
     "openshift_worker_instance_type": "m5.2xlarge",

--- a/dags/openshift_nightlies/config/install/aws/ovn-dp.json
+++ b/dags/openshift_nightlies/config/install/aws/ovn-dp.json
@@ -2,7 +2,7 @@
     "openshift_client_location": "",
     "openshift_install_binary_url": "",
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 6,
     "openshift_host_prefix": "22",
     "openshift_network_type": "OVNKubernetes",
     "openshift_master_instance_type": "r5.xlarge",

--- a/dags/openshift_nightlies/config/install/azure/acs.json
+++ b/dags/openshift_nightlies/config/install/azure/acs.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 6,
     "openshift_base_domain": "ats.azure.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_master_vm_size": "Standard_E16s_v3",

--- a/dags/openshift_nightlies/config/install/azure/ovn-dp.json
+++ b/dags/openshift_nightlies/config/install/azure/ovn-dp.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 6,
     "openshift_base_domain": "ats.azure.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OVNKubernetes",

--- a/dags/openshift_nightlies/config/install/gcp/acs.json
+++ b/dags/openshift_nightlies/config/install/gcp/acs.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 6,
     "openshift_base_domain": "perfscale.gcp.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_master_instance_type": "n2-highmem-16",

--- a/dags/openshift_nightlies/config/install/gcp/ovn-dp.json
+++ b/dags/openshift_nightlies/config/install/gcp/ovn-dp.json
@@ -1,6 +1,6 @@
 {
     "openshift_master_count": 3,
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 6,
     "openshift_base_domain": "perfscale.gcp.devcluster.openshift.com",
     "openshift_host_prefix": "23",
     "openshift_network_type": "OVNKubernetes",

--- a/dags/openshift_nightlies/config/install/rosa/ocm.json
+++ b/dags/openshift_nightlies/config/install/rosa/ocm.json
@@ -9,7 +9,7 @@
     "ocm_environment": "stage",
     "managed_channel_group": "nightly",
     "managed_ocp_version": "latest",
-    "openshift_worker_count": 3,
+    "openshift_worker_count": 6,
     "openshift_network_type": "OpenShiftSDN",
     "openshift_worker_instance_type": "m5.2xlarge",
     "machineset_metadata_label_prefix": "machine.openshift.io"


### PR DESCRIPTION
### Description
Now Uperf pods will be placed within same AZ to avoid cross zone inconsistent latency in our reports, so need at least 2 nodes per zone.

Increasing worker size of all jobs to have at least 2 nodes per availability zone , one for server and another one for client within same AZ.

https://github.com/cloud-bulldozer/benchmark-operator/pull/811

### Fixes
