### PR TITLE
Trigger must-gather as soon as at least one parent has failed

### DIFF
--- a/dags/openshift_nightlies/config/baremetal-benchmarks/webfuse-bench.json
+++ b/dags/openshift_nightlies/config/baremetal-benchmarks/webfuse-bench.json
@@ -26,8 +26,7 @@
                 "STEP_SIZE": "30s",
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true"
+                "CLEANUP": "true"
             }
         },
         {
@@ -43,8 +42,7 @@
                 "BURST": "20",
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true"
+                "CLEANUP": "true"
             }
         },                
         {

--- a/dags/openshift_nightlies/config/benchmarks/acs.json
+++ b/dags/openshift_nightlies/config/benchmarks/acs.json
@@ -30,7 +30,6 @@
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },
@@ -50,7 +49,6 @@
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },
@@ -79,7 +77,6 @@
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },

--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p75.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p75.json
@@ -17,8 +17,7 @@
                 "LOG_LEVEL": "info",
                 "PLATFORM_ALERTS": "false",
                 "CLEANUP_WHEN_FINISH": "false",
-                "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "false"
+                "CLEANUP": "true"
             }
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p90.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p90.json
@@ -17,8 +17,7 @@
                 "LOG_LEVEL": "info",
                 "PLATFORM_ALERTS": "false",
                 "CLEANUP_WHEN_FINISH": "false",
-                "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "false"
+                "CLEANUP": "true"
             }
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-p75.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-p75.json
@@ -17,8 +17,7 @@
                 "LOG_LEVEL": "info",
                 "PLATFORM_ALERTS": "false",
                 "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "false"
+                "CLEANUP": "true"
             }
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-p90.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-p90.json
@@ -17,8 +17,7 @@
                 "LOG_LEVEL": "info",
                 "PLATFORM_ALERTS": "false",
                 "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "false"
+                "CLEANUP": "true"
             }
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane-mgs.json
@@ -26,7 +26,6 @@
                 "CHURN_DURATION": "1h",
                 "CHURN_DELAY": "2m",
                 "CHURN_PERCENT": "10",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
@@ -51,7 +51,6 @@
                 "PLATFORM_ALERTS": "false",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane-mgs.json
@@ -26,7 +26,6 @@
                 "CHURN_DURATION": "1h",
                 "CHURN_DELAY": "2m",
                 "CHURN_PERCENT": "10",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
@@ -41,7 +41,6 @@
                 "PLATFORM_ALERTS": "false",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },

--- a/dags/openshift_nightlies/config/benchmarks/openstack.json
+++ b/dags/openshift_nightlies/config/benchmarks/openstack.json
@@ -44,7 +44,6 @@
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "CLEANUP_TIMEOUT": "1h",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
@@ -65,7 +64,6 @@
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "CLEANUP_TIMEOUT": "2h",
                 "METRICS_PROFILE": "metrics-profiles/metrics-aggregated.yaml",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"

--- a/dags/openshift_nightlies/config/benchmarks/osp-large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/osp-large-control-plane.json
@@ -44,7 +44,6 @@
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "CLEANUP_TIMEOUT": "1h",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
@@ -65,7 +64,6 @@
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "CLEANUP_TIMEOUT": "2h",
                 "METRICS_PROFILE": "metrics-profiles/metrics-aggregated.yaml",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"

--- a/dags/openshift_nightlies/config/benchmarks/small-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/small-control-plane-mgs.json
@@ -38,7 +38,6 @@
                 "CHURN_DURATION": "1h",
                 "CHURN_DELAY": "2m",
                 "CHURN_PERCENT": "10",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },

--- a/dags/openshift_nightlies/config/benchmarks/small-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/small-control-plane.json
@@ -44,7 +44,6 @@
                 "PLATFORM_ALERTS": "false",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -95,18 +95,6 @@ else
     echo "Running: ${command}"
     eval $command
     benchmark_rv=$?
-
-    if [[ ${MUST_GATHER_EACH_TASK} == "true" && ${benchmark_rv} -eq 1 ]] ; then
-        echo -e "must gather collection enabled for this task"
-        cd ../../utils/scale-ci-diagnosis
-        export OUTPUT_DIR=$PWD
-        export PROMETHEUS_CAPTURE=false
-        export PROMETHEUS_CAPTURE_TYPE=full
-        export OPENSHIFT_MUST_GATHER=true
-        export STORAGE_MODE=snappy
-        export WORKLOAD=$AIRFLOW_CTX_TASK_ID-must-gather
-        ./ocp_diagnosis.sh > /dev/null
-    fi
 fi
 echo $UUID
 exit $benchmark_rv

--- a/dags/openshift_nightlies/tasks/benchmarks/defaults.json
+++ b/dags/openshift_nightlies/tasks/benchmarks/defaults.json
@@ -28,7 +28,6 @@
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },
@@ -46,7 +45,6 @@
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },
@@ -73,7 +71,6 @@
                 "LOG_LEVEL": "info",
                 "CLEANUP_WHEN_FINISH": "true",
                 "CLEANUP": "true",
-                "MUST_GATHER_EACH_TASK": "true",
                 "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
             }
         },

--- a/dags/openshift_nightlies/tasks/utils/scale_ci_diagnosis.py
+++ b/dags/openshift_nightlies/tasks/utils/scale_ci_diagnosis.py
@@ -3,20 +3,12 @@ from openshift_nightlies.util import var_loader, executor, constants
 from openshift_nightlies.models.release import OpenshiftRelease
 from common.models.dag_config import DagConfig
 
-import json
-from datetime import timedelta
 from airflow.operators.bash import BashOperator
-from airflow.models import Variable
-from airflow.models import DAG
-from airflow.utils.task_group import TaskGroup
-from kubernetes.client import models as k8s
-
-
 
 
 class Diagnosis():
-    def __init__(self, dag, config: DagConfig, release: OpenshiftRelease):
 
+    def __init__(self, dag, config: DagConfig, release: OpenshiftRelease):
         # General DAG Configuration
         self.dag = dag
         self.release = release
@@ -27,7 +19,7 @@ class Diagnosis():
         # Specific Task Configuration
         self.vars = var_loader.build_task_vars(
             release=self.release, task="utils")
-        self.git_name=self._git_name()
+        self.git_name = self._git_name()
         self.env = {
             "SNAPPY_DATA_SERVER_URL": self.snappy_creds['server'],
             "SNAPPY_DATA_SERVER_USERNAME": self.snappy_creds['username'],
@@ -37,22 +29,21 @@ class Diagnosis():
         }
         self.env.update(self.config.dependencies)
 
-
     def _git_name(self):
         git_username = var_loader.get_git_user()
         if git_username == 'cloud-bulldozer':
-            return f"perf-ci"
-        else: 
+            return "perf-ci"
+        else:
             return f"{git_username}"
 
     def get_utils(self):
         utils = self._get_utils(self.vars["utils"])
         return utils
 
-    def _get_utils(self,utils):
+    def _get_utils(self, utils):
         for index, util in enumerate(utils):
             utils[index] = self._get_util(util)
-        return utils 
+        return utils
 
     def _get_util(self, util):
         env = {**self.env, **util.get('env', {}), **{"ES_SERVER": var_loader.get_secret('elasticsearch')}, **{"KUBEADMIN_PASSWORD": environ.get("KUBEADMIN_PASSWORD", "")}}
@@ -63,7 +54,6 @@ class Diagnosis():
             retries=3,
             dag=self.dag,
             env=env,
-            executor_config=self.exec_config
+            executor_config=self.exec_config,
+            trigger_rule="one_failed"
         )
-
-


### PR DESCRIPTION
### Description

The default value of the trigger_rule is `all_success`. [Docs](https://airflow.apache.org/docs/apache-airflow/2.3.2/concepts/dags.html#trigger-rules)

When one of the benchmarks fails we should must-gather the cluster from here:

This is what is happening now in tasks where MUST_GATHER_EACH_TASK is not `true`:
![image](https://user-images.githubusercontent.com/4614641/236199735-04b1db0c-3c3e-420b-b63b-97e0850a2f20.png)
On the other hand, in case we merge this PR, do we need to must-gather from the run_benchmark.sh script?. I think they are redundant and confusing:

https://github.com/cloud-bulldozer/airflow-kubernetes/blob/ab1bbcd6a524dfc87c83ac0e6220f22b55d9a44e/dags/openshift_nightlies/scripts/run_benchmark.sh#L99-L109