### PR TITLE
Migrage cluster-density to ocp wrapper

### DIFF
--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane-mgs.json
@@ -4,36 +4,19 @@
             "name": "node-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=10s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=10s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "command": "./run.sh",
-            "env": {
-                "WORKLOAD": "cluster-density",
-                "JOB_ITERATIONS": "4000",
-                "JOB_TIMEOUT": "18000",
-                "STEP_SIZE": "30s",
-                "QPS": "20",
-                "BURST": "20",
-                "LOG_LEVEL": "info",
-                "PLATFORM_ALERTS": "false",
-                "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "CHURN": "true",
-                "CHURN_DURATION": "1h",
-                "CHURN_DELAY": "2m",
-                "CHURN_PERCENT": "10",
-                "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
-            }
+            "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=4000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=3000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --churn=true --churn-delay=2m --churn-duration=1h --churn-percent=10"
+            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=3000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
@@ -34,31 +34,19 @@
             "name": "node-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=10s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=10s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "command": "./run.sh",
-            "env": {
-                "WORKLOAD": "cluster-density",
-                "JOB_ITERATIONS": "4000",
-                "JOB_TIMEOUT": "18000",
-                "QPS": "20",
-                "BURST": "20",
-                "LOG_LEVEL": "info",
-                "PLATFORM_ALERTS": "false",
-                "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
-            }
+            "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=4000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=3000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --churn=true --churn-delay=2m --churn-duration=1h --churn-percent=10"
+            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=3000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane-mgs.json
@@ -4,36 +4,19 @@
             "name": "node-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "command": "./run.sh",
-            "env": {
-                "WORKLOAD": "cluster-density",
-                "JOB_ITERATIONS": "1000",
-                "JOB_TIMEOUT": "18000",
-                "STEP_SIZE": "30s",
-                "QPS": "20",
-                "BURST": "20",
-                "LOG_LEVEL": "info",
-                "PLATFORM_ALERTS": "false",
-                "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "CHURN": "true",
-                "CHURN_DURATION": "1h",
-                "CHURN_DELAY": "2m",
-                "CHURN_PERCENT": "10",
-                "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
-            }
+            "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=1000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=750 --timeout=5h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --churn=true --churn-delay=2m --churn-duration=1h --churn-percent=10"
+            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=750 --timeout=5h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
@@ -24,31 +24,19 @@
             "name": "node-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "command": "./run.sh",
-            "env": {
-                "WORKLOAD": "cluster-density",
-                "JOB_ITERATIONS": "1000",
-                "JOB_TIMEOUT": "18000",
-                "QPS": "20",
-                "BURST": "20",
-                "LOG_LEVEL": "info",
-                "PLATFORM_ALERTS": "false",
-                "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
-            }
+            "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=1000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=750 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --churn=true --churn-delay=2m --churn-duration=1h --churn-percent=10"
+            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=750 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/osp-large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/osp-large-control-plane.json
@@ -31,43 +31,16 @@
             }
         },
         {
-            "name": "cluster-density-3000",
-            "workload": "kube-burner",
-            "command": "./run.sh",
-            "env": {
-                "WORKLOAD": "cluster-density",
-                "JOB_ITERATIONS": "3000",
-                "JOB_TIMEOUT": "18000",
-                "STEP_SIZE": "2m",
-                "QPS": "20",
-                "BURST": "20",
-                "LOG_LEVEL": "info",
-                "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "CLEANUP_TIMEOUT": "1h",
-                "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
-            }
-        },
-        {
             "name": "node-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "command": "./run.sh",
-            "env": {
-                "WORKLOAD": "node-density",
-                "PODS_PER_NODE": "245",
-                "NODE_COUNT": "252",
-                "JOB_TIMEOUT": "18000",
-                "QPS": "20",
-                "BURST": "20",
-                "STEP_SIZE": "2m",
-                "LOG_LEVEL": "info",
-                "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "CLEANUP_TIMEOUT": "2h",
-                "METRICS_PROFILE": "metrics-profiles/metrics-aggregated.yaml",
-                "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
-            }
+            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=10s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+        },
+        {
+            "name": "cluster-density",
+            "workload": "kube-burner",
+            "trigger_rule": "all_done",
+            "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=3000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/small-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/small-control-plane-mgs.json
@@ -4,48 +4,31 @@
             "name": "node-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "node-density-heavy",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp node-density-heavy --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+            "custom_cmd": "kube-burner ocp node-density-heavy --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "node-density-cni",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp node-density-cni --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+            "custom_cmd": "kube-burner ocp node-density-cni --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "command": "./run.sh",
-            "env": {
-                "WORKLOAD": "cluster-density",
-                "JOB_ITERATIONS": "500",
-                "JOB_TIMEOUT": "18000",
-                "STEP_SIZE": "30s",
-                "QPS": "20",
-                "BURST": "20",
-                "LOG_LEVEL": "info",
-                "PLATFORM_ALERTS": "false",
-                "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "CHURN": "true",
-                "CHURN_DURATION": "1h",
-                "CHURN_DELAY": "2m",
-                "CHURN_PERCENT": "10",
-                "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
-            }
+            "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=500 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=500 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --churn=true --churn-delay=2m --churn-duration=1h --churn-percent=10"
+            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=500 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/small-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/small-control-plane.json
@@ -14,44 +14,31 @@
             "name": "node-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "node-density-heavy",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp node-density-heavy --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+            "custom_cmd": "kube-burner ocp node-density-heavy --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "node-density-cni",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp node-density-cni --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+            "custom_cmd": "kube-burner ocp node-density-cni --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "command": "./run.sh",
-            "env": {
-                "WORKLOAD": "cluster-density",
-                "JOB_ITERATIONS": "500",
-                "JOB_TIMEOUT": "18000",
-                "STEP_SIZE": "30s",
-                "QPS": "20",
-                "BURST": "20",
-                "LOG_LEVEL": "info",
-                "PLATFORM_ALERTS": "false",
-                "CLEANUP_WHEN_FINISH": "true",
-                "CLEANUP": "true",
-                "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
-            }
+            "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=500 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
             "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=500 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=500 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/upgrade.json
+++ b/dags/openshift_nightlies/config/benchmarks/upgrade.json
@@ -1,21 +1,10 @@
 {
     "benchmarks": [
         {
-            "name": "load-cluster-preupgrade",
+            "name": "cluster-density",
             "workload": "kube-burner",
-            "command": "./run.sh",
-            "env": {
-                "WORKLOAD": "cluster-density",
-                "JOB_ITERATIONS": "500",
-                "JOB_TIMEOUT": "18000",
-                "STEP_SIZE": "30s",
-                "QPS": "20",
-                "BURST": "20",
-                "LOG_LEVEL": "info",
-                "CLEANUP_WHEN_FINISH": "false",
-                "CLEANUP": "true",
-                "NODE_SELECTOR": "{node-role.kubernetes.io/workload: }"
-            }
+            "trigger_rule": "all_done",
+            "custom_cmd": "kube-burner ocp cluster-density --iterations=500 --timeout=2h -churn=false --gc=false"
         },
         {
             "name": "upgrades",
@@ -26,9 +15,9 @@
                 "ROSA_VERSION_CHANNEL": "candidate",
                 "TIMEOUT": "400",
                 "POLL_INTERVAL": "10",
-		"ES_INDEX": "managedservices-timings"
+                "ES_INDEX": "managedservices-timings"
             },
-	    "executor_image": "airflow-managed-services"
+	        "executor_image": "airflow-managed-services"
         }
    ]
 }

--- a/dags/openshift_nightlies/scripts/run_benchmark.sh
+++ b/dags/openshift_nightlies/scripts/run_benchmark.sh
@@ -22,6 +22,7 @@ setup(){
     export GSHEET_KEY_LOCATION=/tmp/key.json
     export RUN_ID=${AIRFLOW_CTX_DAG_ID}/${AIRFLOW_CTX_DAG_RUN_ID}/$AIRFLOW_CTX_TASK_ID
     export SNAPPY_RUN_ID=${AIRFLOW_CTX_DAG_ID}/${AIRFLOW_CTX_DAG_RUN_ID}
+    echo "cpt: true" > metadata.yml
 
     curl -sS https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz oc
 


### PR DESCRIPTION
Also removing the `--churn=true --churn-delay=2m --churn-duration=1h` flags, since they are defaulted,

And adding the `--user-metadata` flag to the commands in order to index the field `cpt: true` along with the workload metrics. cc: @jtaleric 