### PR TITLE
Update cleanup trigger rule to all_done

### DIFF
--- a/dags/openshift_nightlies/tasks/install/openshift.py
+++ b/dags/openshift_nightlies/tasks/install/openshift.py
@@ -73,7 +73,7 @@ class AbstractOpenshiftInstaller(ABC):
 
     def get_cleanup_task(self):
         # trigger_rule = "all_done" means this task will run when every other task has finished, whether it fails or succeededs
-        return self._get_task(operation="cleanup")
+        return self._get_task(operation="cleanup", trigger_rule="all_done")
 
     def _setup_task(self, operation="install"):
         self.config = {**self.config,

--- a/dags/openshift_nightlies/tasks/utils/defaults.json
+++ b/dags/openshift_nightlies/tasks/utils/defaults.json
@@ -1,5 +1,5 @@
 {
-    "utils": [
+    "must_gather":
         {
             "name": "must-gather",
             "workload": "scale-ci-diagnosis",
@@ -11,5 +11,4 @@
                 "STORAGE_MODE": "snappy"
             }
         }
-    ]
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -49,7 +49,7 @@ output_info() {
         _results_api_url=$(oc get route/perf-dashboard-api -o jsonpath='{.spec.host}' -n dashboard)
 
         printf "\n\n Results Dashboard Configs"
-        printf "\n Dashboard URL: $_results_dashboard_url \n API Endpoint: $_results_api_url \n"
+        printf "\n Dashboard URL: http://$_results_dashboard_url \n API Endpoint: http://$_results_api_url \n"
     fi
 
 }

--- a/scripts/playground/build.sh
+++ b/scripts/playground/build.sh
@@ -21,7 +21,7 @@ fi
 echo -e "Release Name:    \t $_airflow_namespace"
 echo -e "Airflow Namespace: \t $_airflow_namespace"
 
-oc create ns $_airflow_namespace || true
+oc new-project $_airflow_namespace || true
 oc label namespace $_airflow_namespace mode=playground || true
 envsubst < $GIT_ROOT/scripts/playground/templates/airflow.yaml | kubectl apply -f -
 output_info


### PR DESCRIPTION
### Description

The PR https://github.com/cloud-bulldozer/airflow-kubernetes/pull/315 has a bug and leads to the deployed clusters not being pruned when all the upstream tasks from the DAG succeeded

![image](https://github.com/cloud-bulldozer/airflow-kubernetes/assets/4614641/45f8b6ef-6651-4da2-8108-2d63036e908f)

We should execute cleanup always

Apart from that, I realized that must-gather only runs only when the upstream task fails, (where upstream means the directly preceding task). For that reason I've modified the code to add a must-gather task to each benchmark, so it gets executed only when that benchmark fails as I show below:

![image](https://github.com/cloud-bulldozer/airflow-kubernetes/assets/4614641/17904db5-b718-49f4-918f-0c796c1b2157)
 