### PR TITLE
Bump kube-burner version

### DIFF
--- a/images/airflow/Dockerfile
+++ b/images/airflow/Dockerfile
@@ -14,7 +14,7 @@ RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | b
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6
 
-RUN curl -L https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.5/kube-burner-1.5-Linux-x86_64.tar.gz | tar xz -C /usr/bin kube-burner
+RUN curl -L https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.6/kube-burner-1.6-Linux-x86_64.tar.gz | tar xz -C /usr/bin kube-burner
 RUN curl -L https://github.com/jtaleric/k8s-netperf/releases/download/v0.0.7/k8s-netperf_0.0.7_linux_amd64.tar.gz  | tar xz -C /usr/bin k8s-netperf
 USER airflow
 RUN pip install prometheus-api-client elasticsearch apache-airflow-providers-elasticsearch apache-airflow-providers-cncf-kubernetes --upgrade


### PR DESCRIPTION
### Description

Release notes: https://github.com/cloud-bulldozer/kube-burner/releases/tag/v1.6

