### PR TITLE
Fix final_dag task and add failed tasks detail to the slack message

### DIFF
--- a/dags/common/util/slack_integration.py
+++ b/dags/common/util/slack_integration.py
@@ -1,54 +1,51 @@
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
-import logging
-from os import environ
 from common.util import var_loader
 
 SLACK_CONN_ID = 'slack'
 
+
 def alert_members(context):
 
-    dag_id = context.get('task_instance').dag_id 
-    managed_services_terms = [ "rosa", "rogcp", "-aro-" ] 
-    perf_core_terms = ["aws", "azure", "-gcp-","baremetal"]
-
-    if any(term in dag_id for term in managed_services_terms):
-        members = " @perfscale-managed-services-team"
-    elif any(term in dag_id for term in perf_core_terms):
-        members=" @perfscale-core-team"
-    elif "openstack" in dag_id:
-        members=" @Masco"
+    dag_id = context.get('task_instance').dag_id
+    if "openstack" in dag_id:
+        members = "@Masco"
     else:
-        members=""
-    return members    
+        members = "@perfscale-team"
+    return members
+
 
 def get_hyperlink(context):
-    link= "<{0}|Dag Link>".format(context.get('task_instance').log_url)
-    return str(link)        
+    link = "<{0}|Dag Link>".format(context.get('task_instance').log_url)
+    return str(link)
 
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
+    ti = context.get('task_instance')
+    if context.get('task_instance').task_id == "final_status":
+        failed_tasks = ti.xcom_pull(key="failed_tasks", task_ids="final_status")
+        print(f"Failed tasks: {failed_tasks}")
+    else:
+        return
+    # If the git user is not cloud-bulldozer, skip pushing message to slack
     if var_loader.get_git_user() != "cloud-bulldozer":
-        print("Task Failed")
         return
-    if context.get('task_instance').task_id != "final_status":
-        print(context.get('task_instance').task_id,"Task failed")
-        return
-   
+
     slack_msg = """
-            :red_circle: DAG Failed {mem} 
-            *Task*: {task}  
-            *Dag*: {dag} 
-            *Execution Time*: {exec_date}  
-            *Log Url*: {log_url} 
+            :red_circle: DAG Failed {mem}
+            *Task*: {task}
+            *Dag*: {dag}
+            *Execution Time*: {exec_date}
+            *Log Url*: {log_url}
+            *Failed tasks*: {failed_tasks}
             """.format(
             task=context.get('task_instance').task_id,
             dag=context.get('task_instance').dag_id,
             mem=alert_members(context),
-            ti=context.get('task_instance'),
             exec_date=context.get('execution_date'),
             log_url=get_hyperlink(context),
+            failed_tasks=failed_tasks
         )
     failed_alert = SlackWebhookOperator(
         task_id='slack_test',


### PR DESCRIPTION
### Description

Example showing two DAG runs, first one with a failed task and a second one w/o any failure:

![image](https://github.com/cloud-bulldozer/airflow-kubernetes/assets/4614641/2fefb423-38cb-4f84-8e7c-4943b376be00)


Some linting as well.