### PR TITLE
Fix DAG trigger_rules

### DIFF
--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p75.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p75.json
@@ -3,7 +3,6 @@
         {
             "name": "cluster-density-ms-p75",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "cluster-density-ms",

--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p90.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-chaos-p90.json
@@ -3,7 +3,6 @@
         {
             "name": "cluster-density-ms-p90",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "cluster-density-ms",

--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-p75.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-p75.json
@@ -3,7 +3,6 @@
         {
             "name": "cluster-density-ms-p75",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "cluster-density-ms",

--- a/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-p90.json
+++ b/dags/openshift_nightlies/config/benchmarks/hosted-control-plane-p90.json
@@ -3,7 +3,6 @@
         {
             "name": "cluster-density-ms-p90",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "cluster-density-ms",

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane-mgs.json
@@ -3,19 +3,16 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=10s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=4000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=3000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
@@ -33,19 +33,16 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=10s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=4000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=3000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane-mgs.json
@@ -3,19 +3,16 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=1000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=750 --timeout=5h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
@@ -23,19 +23,16 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=1000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=750 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/openstack.json
+++ b/dags/openshift_nightlies/config/benchmarks/openstack.json
@@ -51,7 +51,6 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "command": "./run.sh",
             "env": {
                 "WORKLOAD": "node-density",

--- a/dags/openshift_nightlies/config/benchmarks/osp-large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/osp-large-control-plane.json
@@ -33,13 +33,11 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=10s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=3000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/small-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/small-control-plane-mgs.json
@@ -3,31 +3,26 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "node-density-heavy",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp node-density-heavy --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "node-density-cni",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp node-density-cni --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=500 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=500 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/small-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/small-control-plane.json
@@ -13,31 +13,26 @@
         {
             "name": "node-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "node-density-heavy",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp node-density-heavy --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "node-density-cni",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp node-density-cni --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=500 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         },
         {
             "name": "cluster-density-v2",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
             "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=500 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
         }
     ]

--- a/dags/openshift_nightlies/config/benchmarks/upgrade.json
+++ b/dags/openshift_nightlies/config/benchmarks/upgrade.json
@@ -3,8 +3,7 @@
         {
             "name": "cluster-density",
             "workload": "kube-burner",
-            "trigger_rule": "all_done",
-            "custom_cmd": "kube-burner ocp cluster-density --iterations=500 --timeout=2h -churn=false --gc=false"
+            "custom_cmd": "kube-burner ocp cluster-density --iterations=500 --timeout=2h --churn=false --gc=false"
         },
         {
             "name": "upgrades",

--- a/dags/openshift_nightlies/dag.py
+++ b/dags/openshift_nightlies/dag.py
@@ -155,36 +155,30 @@ class OpenstackNightlyDAG(AbstractOpenshiftNightlyDAG):
 class RosaNightlyDAG(AbstractOpenshiftNightlyDAG):
     def build(self):
         installer = self._get_openshift_installer()
-        if self.config.cleanup_on_success:
-            if installer.get_type() == "rosa_hcp":
-                install_cluster = installer.get_install_hcp_task()
-                hosted_installer = self._get_hypershift_openshift_installer()
-                wait_task = hosted_installer.wait_task()
-                wait_before_cleanup = hosted_installer.wait_task(id="wait_before_cleanup")
-                for c_id, install_hc, cleanup_hc in install_cluster:
-                    benchmark = self._add_benchmarks(task_group=c_id)
-                    install_hc >> wait_task >> benchmark >> wait_before_cleanup >> cleanup_hc
-            else:
-                install_cluster = installer.get_install_task()
-                final_status=final_dag_status.get_task(self.dag)
-                with TaskGroup("benchmarks", prefix_group_id=False, dag=self.dag) as benchmarks:
-                    must_gather = self._get_scale_ci_diagnosis().get_must_gather("must-gather")
-                    benchmark_tasks = self._get_e2e_benchmarks().get_benchmarks()
-                    chain(*benchmark_tasks)
-                    # Configure must_gather as downstream of all benchmark tasks
-                    for benchmark in benchmark_tasks:
-                        benchmark >> must_gather
-                rosa_post_installation = self._get_rosa_postinstall_setup()._get_rosa_postinstallation()
-                cleanup_cluster = installer.get_cleanup_task()
-                install_cluster >> rosa_post_installation >> benchmarks >> cleanup_cluster >> final_status
+        if installer.get_type() == "rosa_hcp":
+            install_cluster = installer.get_install_hcp_task()
+            hosted_installer = self._get_hypershift_openshift_installer()
+            wait_task = hosted_installer.wait_task()
+            wait_before_cleanup = hosted_installer.wait_task(id="wait_before_cleanup")
+            for c_id, install_hc, cleanup_hc in install_cluster:
+                benchmark = self._add_benchmarks(task_group=c_id)
+                install_hc >> wait_task >> benchmark >> wait_before_cleanup >> cleanup_hc
         else:
             install_cluster = installer.get_install_task()
-            final_status=final_dag_status.get_task(self.dag)
+            final_status = final_dag_status.get_task(self.dag)
             with TaskGroup("benchmarks", prefix_group_id=False, dag=self.dag) as benchmarks:
+                must_gather = self._get_scale_ci_diagnosis().get_must_gather("must-gather")
                 benchmark_tasks = self._get_e2e_benchmarks().get_benchmarks()
                 chain(*benchmark_tasks)
+                # Configure must_gather as downstream of all benchmark tasks
+                for benchmark in benchmark_tasks:
+                    benchmark >> must_gather
             rosa_post_installation = self._get_rosa_postinstall_setup()._get_rosa_postinstallation()
-            install_cluster >> rosa_post_installation >> benchmarks
+            if self.config.cleanup_on_success:
+                cleanup_cluster = installer.get_cleanup_task()
+                install_cluster >> rosa_post_installation >> benchmarks >> cleanup_cluster >> final_status
+            else:
+                install_cluster >> rosa_post_installation >> benchmarks >> final_status
 
     def _get_openshift_installer(self):
         return rosa.RosaInstaller(self.dag, self.config, self.release)
@@ -206,15 +200,19 @@ class RoGCPNightlyDAG(AbstractOpenshiftNightlyDAG):
     def build(self):
         installer = self._get_openshift_installer()
         install_cluster = installer.get_install_task()
-        final_status=final_dag_status.get_task(self.dag)
+        final_status = final_dag_status.get_task(self.dag)
         with TaskGroup("benchmarks", prefix_group_id=False, dag=self.dag) as benchmarks:
             benchmark_tasks = self._get_e2e_benchmarks().get_benchmarks()
+            must_gather = self._get_scale_ci_diagnosis().get_must_gather("must-gather")
             chain(*benchmark_tasks)
+            # Configure must_gather as downstream of all benchmark tasks
+            for benchmark in benchmark_tasks:
+                benchmark >> must_gather
         if self.config.cleanup_on_success:
             cleanup_cluster = installer.get_cleanup_task()
             install_cluster >> benchmarks >> cleanup_cluster >> final_status
         else:
-            install_cluster >> benchmarks
+            install_cluster >> benchmarks >> final_status
 
     def _get_openshift_installer(self):
         return rogcp.RoGCPInstaller(self.dag, self.config, self.release)


### PR DESCRIPTION
### Description

When a benchmark task fails must-gather should be executed and the subsequent benchmkarks should be skipped as well. 

There's an issue in the current implementation:

![image](https://github.com/cloud-bulldozer/airflow-kubernetes/assets/4614641/e3b3bf18-223b-4594-847f-06bac756714c)

When must-gather is skipped, all the downstream tasks are skipped too. This happens because the DAG execution pipeline is sequential and does not have any branch

![image](https://github.com/cloud-bulldozer/airflow-kubernetes/assets/4614641/e72395f4-b448-437e-b99c-1396d0429448)


In the new implementation it has been updated to:

![image](https://github.com/cloud-bulldozer/airflow-kubernetes/assets/4614641/bcb1e990-c898-477f-a388-a392432b256e)

All benchmark's tasks trigger_rules are all_succeed, meaning that when a benchmark fails must-gather will run. Summarizing:

![image](https://github.com/cloud-bulldozer/airflow-kubernetes/assets/4614641/36c8e45d-4c92-43d3-a978-a95f6df9edc3)
