### PR TITLE
delete and retry errored rosa cluster

### DIFF
--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -649,7 +649,9 @@ if [[ "$operation" == "install" ]]; then
 	    postinstall
     elif [ "${CLUSTER_STATUS}" == "error" ] ; then
         printf "INFO: Cluster ${CLUSTER_NAME} errored, cleaning them now..."
-	    cleanup  
+	    cleanup
+        printf "INFO: Fail this install to re-try a fresh install"
+        exit 1
     else
         printf "INFO: Cluster ${CLUSTER_NAME} already installed but not ready, exiting..."
 	    exit 1

--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -647,6 +647,9 @@ if [[ "$operation" == "install" ]]; then
     elif [ "${CLUSTER_STATUS}" == "ready" ] ; then
         printf "INFO: Cluster ${CLUSTER_NAME} already installed and ready, reusing..."
 	    postinstall
+    elif [ "${CLUSTER_STATUS}" == "error" ] ; then
+        printf "INFO: Cluster ${CLUSTER_NAME} errored, cleaning them now..."
+	    cleanup  
     else
         printf "INFO: Cluster ${CLUSTER_NAME} already installed but not ready, exiting..."
 	    exit 1

--- a/dags/openshift_nightlies/scripts/install/rosa.sh
+++ b/dags/openshift_nightlies/scripts/install/rosa.sh
@@ -646,15 +646,15 @@ if [[ "$operation" == "install" ]]; then
         fi
     elif [ "${CLUSTER_STATUS}" == "ready" ] ; then
         printf "INFO: Cluster ${CLUSTER_NAME} already installed and ready, reusing..."
-	    postinstall
+        postinstall
     elif [ "${CLUSTER_STATUS}" == "error" ] ; then
         printf "INFO: Cluster ${CLUSTER_NAME} errored, cleaning them now..."
-	    cleanup
+        cleanup
         printf "INFO: Fail this install to re-try a fresh install"
         exit 1
     else
         printf "INFO: Cluster ${CLUSTER_NAME} already installed but not ready, exiting..."
-	    exit 1
+        exit 1
     fi
 
 elif [[ "$operation" == "cleanup" ]]; then


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If a ROSA cluster install fails due to a build failure, the tasks fails and re-try is useless on an `error`ed cluster so adding this small patch to kick in a destroy and re-try for a fresh build.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
