### PR TITLE
remove `oc login` from diagnosis script

### DIFF
--- a/dags/openshift_nightlies/scripts/utils/run_scale_ci_diagnosis.sh
+++ b/dags/openshift_nightlies/scripts/utils/run_scale_ci_diagnosis.sh
@@ -27,10 +27,6 @@ setup(){
     curl -sS https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz oc
 
     export PATH=$PATH:$(pwd)
-
-    if [[ ! -z "$KUBEADMIN_PASSWORD" ]]; then 
-        oc login -u kubeadmin -p $KUBEADMIN_PASSWORD --insecure-skip-tls-verify
-    fi
 }
 
 setup


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Issue: ROSA cluster must-gather were failing because of wrong kube admin user account. 
But pod got the `KUBECONFIG` environment set already, so oc login command becomes obsolete.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
