### PR TITLE
Stop using custom_cmd for control-plane DAGs

### DIFF
--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane-mgs.json
@@ -2,13 +2,22 @@
     "benchmarks": [
         {
             "name": "node-density",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=3h --pod-ready-threshold=10s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "node-density",
+                "EXTRA_FLAGS": "--pod-ready-threshold=10s"
+            }
         },
         {
             "name": "cluster-density-v2",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=3000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml --gc=false"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "cluster-density-v2",
+                "ITERATIONS": "2268",
+                "EXTRA_FLAGS": "--timeout=6h"
+            }
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/large-control-plane.json
@@ -32,13 +32,22 @@
         },
         {
             "name": "node-density",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=3h --pod-ready-threshold=10s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "node-density",
+                "EXTRA_FLAGS": "--pod-ready-threshold=10s"
+            }
         },
         {
             "name": "cluster-density-v2",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=3000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml --gc=false"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "cluster-density-v2",
+                "ITERATIONS": "2268",
+                "EXTRA_FLAGS": "--timeout=6h"
+            }
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane-mgs.json
@@ -2,13 +2,22 @@
     "benchmarks": [
         {
             "name": "node-density",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=3h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "node-density",
+                "EXTRA_FLAGS": "--pod-ready-threshold=10s"
+            }
         },
         {
             "name": "cluster-density-v2",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=750 --timeout=5h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml --gc=false"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "cluster-density-v2",
+                "ITERATIONS": "1080",
+                "EXTRA_FLAGS": "--timeout=5h"
+            }
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/medium-control-plane.json
@@ -22,13 +22,22 @@
         },
         {
             "name": "node-density",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=3h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "node-density",
+                "EXTRA_FLAGS": "--pod-ready-threshold=10s"
+            }
         },
         {
             "name": "cluster-density-v2",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=750 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml --gc=false"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "cluster-density-v2",
+                "ITERATIONS": "1080",
+                "EXTRA_FLAGS": "--timeout=5h"
+            }
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/osp-large-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/osp-large-control-plane.json
@@ -32,13 +32,22 @@
         },
         {
             "name": "node-density",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=10s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "node-density",
+                "EXTRA_FLAGS": "--pod-ready-threshold=10s"
+            }
         },
         {
-            "name": "cluster-density",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp cluster-density --uuid=${UUID} --iterations=3000 --timeout=6h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "name": "cluster-density-v2",
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "cluster-density-v2",
+                "ITERATIONS": "2268",
+                "EXTRA_FLAGS": "--timeout=5h"
+            }
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/small-control-plane-mgs.json
+++ b/dags/openshift_nightlies/config/benchmarks/small-control-plane-mgs.json
@@ -2,23 +2,40 @@
     "benchmarks": [
         {
             "name": "node-density",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=5s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "node-density",
+                "EXTRA_FLAGS": "--pod-ready-threshold=15s --timeout=2h"
+            }
         },
         {
             "name": "node-density-heavy",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp node-density-heavy --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "node-density-heavy",
+                "EXTRA_FLAGS": "--timeout=2h"
+            }
         },
         {
             "name": "node-density-cni",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp node-density-cni --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "node-density-cni",
+                "EXTRA_FLAGS": "--timeout=2h"
+            }
         },
         {
             "name": "cluster-density-v2",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=500 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml --gc=false"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "cluster-density-v2",
+                "ITERATIONS": "216",
+                "EXTRA_FLAGS": "--timeout=3h"
+            }
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/small-control-plane.json
+++ b/dags/openshift_nightlies/config/benchmarks/small-control-plane.json
@@ -12,23 +12,40 @@
         },
         {
             "name": "node-density",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp node-density --uuid=${UUID} --pods-per-node=245 --timeout=2h --pod-ready-threshold=15s --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "node-density",
+                "EXTRA_FLAGS": "--pod-ready-threshold=15s --timeout=2h"
+            }
         },
         {
             "name": "node-density-heavy",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp node-density-heavy --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "node-density-heavy",
+                "EXTRA_FLAGS": "--timeout=2h"
+            }
         },
         {
             "name": "node-density-cni",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp node-density-cni --uuid=${UUID} --pods-per-node=245 --timeout=2h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "node-density-cni",
+                "EXTRA_FLAGS": "--timeout=2h"
+            }
         },
         {
             "name": "cluster-density-v2",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp cluster-density-v2 --uuid=${UUID} --iterations=500 --timeout=3h --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner --user-metadata=metadata.yml --gc=false"
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "cluster-density-v2",
+                "ITERATIONS": "216",
+                "EXTRA_FLAGS": "--timeout=3h"
+            }
         }
     ]
 }

--- a/dags/openshift_nightlies/config/benchmarks/upgrade.json
+++ b/dags/openshift_nightlies/config/benchmarks/upgrade.json
@@ -1,9 +1,15 @@
 {
     "benchmarks": [
         {
-            "name": "cluster-density",
-            "workload": "kube-burner",
-            "custom_cmd": "kube-burner ocp cluster-density --iterations=500 --timeout=2h --churn=false --gc=false"
+            "name": "cluster-density-v2",
+            "workload": "kube-burner-ocp-wrapper",
+            "command": "./run.sh",
+            "env": {
+                "WORKLOAD": "cluster-density-v2",
+                "ITERATIONS": "2268",
+                "EXTRA_FLAGS": "--timeout=2h --gc=false",
+                "CHURN": "false"
+            }
         },
         {
             "name": "upgrades",

--- a/images/airflow/Dockerfile
+++ b/images/airflow/Dockerfile
@@ -14,7 +14,4 @@ RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | b
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6
 
-RUN curl -L $(curl -s https://api.github.com/repos/cloud-bulldozer/kube-burner/releases/latest | jq -r '.assets | map(select(.name | test("linux-x86_64"))) | .[0].browser_download_url') | tar xz -C /usr/bin kube-burner 
-RUN curl -L $(curl -s https://api.github.com/repos/cloud-bulldozer/k8s-netperf/releases/latest | jq -r '.assets | map(select(.name | test("Linux.*x86_64"))) | .[0].browser_download_url') | tar xz -C /usr/bin k8s-netperf
-RUN curl -L $(curl -s https://api.github.com/repos/cloud-bulldozer/ingress-perf/releases/latest | jq -r '.assets | map(select(.name | test("Linux.*x86_64"))) | .[0].browser_download_url') | tar xz -C /usr/bin ingress-perf
 USER airflow


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Remove the usage of custom_cmd and use e2e-benchmarking instead for kube-burner based tests. Thanks to this change we don't need any of binaries in the image anymore
