### PR TITLE
Fixes #358

### DIFF
--- a/dags/openshift_nightlies/util/manifest.py
+++ b/dags/openshift_nightlies/util/manifest.py
@@ -28,14 +28,14 @@ class Manifest():
             latest_accepted_release,latest_accepted_release_url = self.request_for_payload(f"{base_url_arm}/{stream_arm}/latest")
             self.latest_releases[stream_arm] = {
                 # Appending "-amd64" seems counterintuitive, but it is correct. Believe me :-)
-                "openshift_client_location": f"{latest_accepted_release_url}/openshift-client-linux-{self.AMD64}-{latest_accepted_release}.tar.gz",
+                "openshift_client_location": f"{latest_accepted_release_url}/openshift-client-linux-{self.AMD64}-rhel8-{latest_accepted_release}.tar.gz",
                 "openshift_install_binary_url": f"{latest_accepted_release_url}/openshift-install-linux-{self.AMD64}-{latest_accepted_release}.tar.gz"
             }
             # All other binaries under the "plain" ci URLs
             url = f"{self.release_stream_base_url}/{stream}/latest"
             latest_accepted_release,latest_accepted_release_url = self.request_for_payload(url)
             self.latest_releases[stream] = {
-                "openshift_client_location": f"{latest_accepted_release_url}/openshift-client-linux-{latest_accepted_release}.tar.gz",
+                "openshift_client_location": f"{latest_accepted_release_url}/openshift-client-linux-amd64-rhel8-{latest_accepted_release}.tar.gz",
                 "openshift_install_binary_url": f"{latest_accepted_release_url}/openshift-install-linux-{latest_accepted_release}.tar.gz"
             }
 

--- a/dags/tests/openshift_nightlies/util/test_manifest.py
+++ b/dags/tests/openshift_nightlies/util/test_manifest.py
@@ -36,7 +36,7 @@ class TestManifest():
     def assert_amd_client(self,stream):
         assert "arm64" not in stream
         assert "openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.17.0-0.nightly-"+ self.year in stream
-        assert "openshift-client-linux-4.17.0-0.nightly-"+ self.year in stream
+        assert "openshift-client-linux-amd64-rhel8-4.17.0-0.nightly-"+ self.year in stream
 
     def test_manifest_amd(self,mocked_manifest):
         stream = mocked_manifest.latest_releases[self.stream]
@@ -51,7 +51,7 @@ class TestManifest():
     def assert_arm_client(self,stream):
         assert "arm64" in stream
         assert "openshift-release-artifacts-arm64.apps.ci.l2s4.p1.openshiftapps.com/4.17.0-0.nightly-arm64-"+self.year in stream
-        assert "openshift-client-linux-amd64-4.17.0-0.nightly-arm64-"+self.year in stream
+        assert "openshift-client-linux-amd64-rhel8-4.17.0-0.nightly-arm64-"+self.year in stream
 
     def test_manifest_arm(self,mocked_manifest):
         stream = mocked_manifest.latest_releases[f"{self.stream}-arm64"]


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

OpenShift 4.14+ client binaries are now published by default for RHEL 9.
Binaries compatible with RHEL 8 are available under a different archive name.

Also, bump the manifest versions to 4.14, 4.15, and 4.16.

## Related Tickets & Documents

- Closes #358

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.